### PR TITLE
[Bugfix] Version 0.3.1 - Fix function parameter syntax and enhance error messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.3.0"
+version = "0.3.1"
 description = "Educational MCP server demonstrating FastMCP 2.0 best practices - Complete learning guide with contributing guidelines and roadmap for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Fix critical bug where multi-parameter functions like `pow(2, 3)` were rejected
- Add enhanced error messages with examples for common syntax mistakes  
- Add `math://functions` resource for function discovery and usage help
- Version bump to 0.3.1 for bugfix release

## Changes Made
### 🐛 Critical Bug Fix
- **Function Parameter Support**: Added comma to `allowed_chars` to enable multi-parameter functions
- **Before**: `pow(2, 3)` failed with "invalid characters" error
- **After**: `pow(2, 3)` correctly returns `8.0`

### ✨ Enhanced User Experience  
- **Better Error Messages**: Specific validation with examples (e.g., "Function 'pow()' requires two parameters: pow(base, exponent). Example: pow(2, 3)")
- **Function Discovery**: New `math://functions` resource provides comprehensive function documentation and examples
- **Syntax Help**: Clear usage notes and common pattern examples

### 🔧 Technical Improvements
- Enhanced expression validation with early syntax checking
- Preserved all existing security measures and FastMCP 2.0 compliance
- Maintained backward compatibility for all existing functionality

## Testing
- ✅ Core functionality: All basic operations work correctly
- ✅ Function calls: `pow(2, 3)`, `sqrt(16)`, `sin(3.14159/2)` all pass
- ✅ Enhanced errors: Better messages for `pow(2)` and similar mistakes
- ✅ New resource: Function discovery documentation loads properly
- ✅ Security: All expression validation and safety measures intact

## Impact
This fixes the main usability issue reported in testing while adding educational value through better documentation and error messages. Essential for user adoption and MCP learning.

**Ready for merge and 0.3.1 release.**