### PR TITLE
[Feature] Add FastMCP Cloud deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,99 @@ uv run pytest tests/ -v
 uv run math-mcp-learning-server
 ```
 
+## FastMCP Cloud Deployment
+
+Deploy this server to [FastMCP Cloud](https://fastmcp.cloud) for hosted, production-ready access without local setup.
+
+### Deployment Configuration
+
+This server includes a `fastmcp.json` configuration file for seamless cloud deployment:
+
+```json
+{
+  "source": {
+    "type": "filesystem",
+    "path": "src/math_mcp/server.py",
+    "entrypoint": "mcp"
+  },
+  "environment": {
+    "type": "uv",
+    "python": ">=3.11",
+    "dependencies": [
+      "fastmcp>=2.0.0",
+      "pydantic>=2.11.9",
+      "matplotlib>=3.8.0",
+      "numpy>=1.26.0"
+    ]
+  },
+  "deployment": {
+    "transport": "http",
+    "log_level": "INFO"
+  }
+}
+```
+
+### Deploy to FastMCP Cloud
+
+1. **Navigate to**: [FastMCP Cloud Dashboard](https://fastmcp.cloud)
+2. **Connect GitHub Repository**: `huguesclouatre/math-mcp-learning-server`
+3. **Deploy**: FastMCP Cloud auto-detects `fastmcp.json` configuration
+4. **Access**: Your server will be available at a provided FastMCP Cloud URL
+
+### Cloud Storage Considerations
+
+**Persistent Workspace Behavior in Cloud:**
+- The persistent workspace (`save_calculation`, `load_variable`) uses ephemeral storage in cloud deployments
+- Saved calculations persist during active sessions but reset on container restart
+- This is standard cloud/serverless behavior and suitable for educational/demonstration purposes
+
+**For production use cases requiring true persistence:**
+- Integrate external storage (S3, database, Redis)
+- Use environment variables for cloud credentials
+- Modify `src/math_mcp/persistence/storage.py` accordingly
+
+### Testing Cloud Deployment
+
+**Using FastMCP Client:**
+
+```python
+from fastmcp import Client
+import asyncio
+
+async def test_cloud_server():
+    # Replace with your actual FastMCP Cloud URL
+    server_url = "https://your-server.fastmcp.app/mcp"
+
+    async with Client(server_url) as client:
+        # Test calculation
+        result = await client.call_tool("calculate", {"expression": "sqrt(16)"})
+        print(result)
+
+        # Test statistics
+        result = await client.call_tool("statistics", {
+            "numbers": [1, 2, 3, 4, 5],
+            "operation": "mean"
+        })
+        print(result)
+
+asyncio.run(test_cloud_server())
+```
+
+**Using Claude Desktop:**
+
+Add to your Claude Desktop config:
+
+```json
+{
+  "mcpServers": {
+    "math-learning-cloud": {
+      "transport": "http",
+      "url": "https://your-server.fastmcp.app/mcp"
+    }
+  }
+}
+```
+
 ## Development
 
 ### Project Structure

--- a/fastmcp.json
+++ b/fastmcp.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://gofastmcp.com/public/schemas/fastmcp.json/v1.json",
+  "source": {
+    "type": "filesystem",
+    "path": "src/math_mcp/server.py",
+    "entrypoint": "mcp"
+  },
+  "environment": {
+    "type": "uv",
+    "python": ">=3.11",
+    "dependencies": [
+      "fastmcp>=2.0.0",
+      "pydantic>=2.11.9",
+      "matplotlib>=3.8.0",
+      "numpy>=1.26.0"
+    ]
+  },
+  "deployment": {
+    "transport": "http",
+    "log_level": "INFO"
+  }
+}


### PR DESCRIPTION
## Summary
Adds FastMCP Cloud deployment support for hosted, production-ready server access without requiring local setup.

## Changes
- ✅ Add `fastmcp.json` configuration file
  - Entrypoint: `src/math_mcp/server.py:mcp`
  - Dependencies: fastmcp, pydantic, matplotlib, numpy
  - HTTP transport for cloud deployment
  - INFO-level logging for production

- ✅ Update README.md with comprehensive cloud deployment section
  - Deployment configuration overview
  - Step-by-step deployment instructions
  - Cloud storage considerations (ephemeral vs persistent)
  - Testing examples with FastMCP Client and Claude Desktop

## Benefits
- Zero code changes required (server already compatible)
- Seamless cloud deployment experience
- Transparent documentation about ephemeral storage behavior
- Production-ready configuration with plotting support

## Educational Impact
- Demonstrates FastMCP 2.0 cloud deployment capabilities
- Shows transport-agnostic MCP server design
- Illustrates cloud-native considerations for stateful features

## MCP Compliance
- FastMCP 2.0 compatible (no code changes needed)
- Transport-agnostic design validated
- HTTP transport tested and working

## Testing
- ✅ Local HTTP testing verified: `fastmcp run src/math_mcp/server.py --transport http --port 8000`
- ✅ fastmcp.json schema validated
- ✅ README deployment instructions reviewed
- Ready for FastMCP Cloud deployment

## Next Steps
After merge, deploy to FastMCP Cloud at https://fastmcp.cloud/clouatre/