### PR TITLE
chore: Bump version to 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.7.0"
+version = "0.7.1"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
## Purpose

Release v0.7.1 - critical hotfix for v0.7.0 cloud deployment failure.

## Changes

- Version bump: 0.7.0 → 0.7.1 in pyproject.toml

## Context

PR #37 fixed the cloud deployment import error. This PR tags the fix as v0.7.1 release.

## Related

- Fix: #37 (Use absolute import for FastMCP Cloud compatibility)