### PR TITLE
fix: Use correct .claude/ directory for output styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,7 +160,7 @@ final_test.py
 
 # Coding agents (critical - prevents accidental commit of AI instructions)
 CLAUDE.md
-.claudecode/
+.claude/
 .amazonq/
 opencode.json
 .codex/


### PR DESCRIPTION
## Issue

Used incorrect directory name  instead of  for output styles.

## Documentation Reference

Per [Claude Code output styles documentation](https://docs.claude.com/en/docs/claude-code/output-styles):
- Project-level output styles must be in `.claude/output-styles/`

## Changes

- ✅ Updated .gitignore: `.claudecode/` → `.claude/`
- ✅ Moved output style file to correct location locally
- ✅ Verified `.claude/` directory is properly ignored

## Impact

Output style can now be properly recognized and activated by Claude Code using:
```
/output-style Strict Git Workflow
```

## Testing

- ✅ All 67 tests passing
- ✅ Type checking clean
- ✅ Linting clean
- ✅ Verified correct directory structure