### PR TITLE
fix: Add PYTHONPATH for FastMCP Cloud deployment

### DIFF
--- a/fastmcp.json
+++ b/fastmcp.json
@@ -14,7 +14,10 @@
       "pydantic>=2.11.9",
       "matplotlib>=3.8.0",
       "numpy>=1.26.0"
-    ]
+    ],
+    "vars": {
+      "PYTHONPATH": "src"
+    }
   },
   "deployment": {
     "transport": "http",


### PR DESCRIPTION
Adds PYTHONPATH=src to environment variables to ensure math_mcp module is discoverable in FastMCP Cloud.

Combined with package installation (.), this resolves the 'No module named math_mcp' error.