### PR TITLE
Migrate repository to clouatre-labs organization

### DIFF
--- a/.github/PYPI_TRUSTED_PUBLISHING.md
+++ b/.github/PYPI_TRUSTED_PUBLISHING.md
@@ -109,7 +109,7 @@ PyPI Package Index
 **Cause:** GitHub environment `pypi` not configured.
 
 **Solution:**
-- Verify environment exists: https://github.com/clouatre/math-mcp-learning-server/settings/environments
+- Verify environment exists: https://github.com/clouatre-labs/math-mcp-learning-server/settings/environments
 - Check workflow references correct environment name
 
 ## References

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ This project maintains a **fast & minimal** philosophy while providing education
 ### **Development Setup**
 ```bash
 # Clone the repository
-git clone https://github.com/clouatre/math-mcp-learning-server.git
+git clone https://github.com/clouatre-labs/math-mcp-learning-server.git
 cd math-mcp-learning-server
 
 # Install dependencies and activate virtual environment
@@ -266,7 +266,7 @@ Once the release is published, GitHub Actions automatically:
 3. ✅ **Publishes to PyPI** - Using Trusted Publishing (no tokens!)
 
 #### **3. Monitor Progress**
-- Watch workflow: https://github.com/clouatre/math-mcp-learning-server/actions
+- Watch workflow: https://github.com/clouatre-labs/math-mcp-learning-server/actions
 - Check PyPI: https://pypi.org/project/math-mcp-learning-server/
 
 #### **4. Verify Release**

--- a/FUTURE_IMPROVEMENTS.md
+++ b/FUTURE_IMPROVEMENTS.md
@@ -282,7 +282,7 @@ uv pip install math-mcp-learning-server[dev]
 uv pip install math-mcp-learning-server[plotting,dev]
 
 # Development (local):
-git clone https://github.com/clouatre/math-mcp-learning-server
+git clone https://github.com/clouatre-labs/math-mcp-learning-server
 cd math-mcp-learning-server
 uv sync --all-extras
 uv run fastmcp dev src/math_mcp/server.py

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This server implements **all official MCP transport modes** per the [MCP specifi
 - `plot_function`: Generate mathematical function plots (base64-encoded PNG)
 - `create_histogram`: Create statistical histograms with distribution analysis
 
-See [Usage Examples](https://github.com/clouatre/math-mcp-learning-server/blob/main/docs/EXAMPLES.md) for detailed examples of each tool.
+See [Usage Examples](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/EXAMPLES.md) for detailed examples of each tool.
 
 ## Available Resources
 
@@ -191,7 +191,7 @@ math-mcp-learning-server/
 
 ```bash
 # Clone the repository
-git clone https://github.com/clouatre/math-mcp-learning-server.git
+git clone https://github.com/clouatre-labs/math-mcp-learning-server.git
 cd math-mcp-learning-server
 
 # Install dependencies (includes plotting support)
@@ -218,15 +218,15 @@ uv run fastmcp dev src/math_mcp/server.py
 3. Implement tool logic with proper validation
 4. Add corresponding tests in `tests/`
 
-See [CONTRIBUTING.md](https://github.com/clouatre/math-mcp-learning-server/blob/main/CONTRIBUTING.md) for detailed guidelines.
+See [CONTRIBUTING.md](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md) for detailed guidelines.
 
 ## Documentation
 
-- **[Cloud Deployment Guide](https://github.com/clouatre/math-mcp-learning-server/blob/main/docs/CLOUD_DEPLOYMENT.md)**: FastMCP Cloud deployment instructions and configuration
-- **[Usage Examples](https://github.com/clouatre/math-mcp-learning-server/blob/main/docs/EXAMPLES.md)**: Practical examples for all tools and resources
-- **[Contributing Guidelines](https://github.com/clouatre/math-mcp-learning-server/blob/main/CONTRIBUTING.md)**: Development workflow, code standards, and testing procedures
-- **[Future Improvements](https://github.com/clouatre/math-mcp-learning-server/blob/main/FUTURE_IMPROVEMENTS.md)**: Roadmap and enhancement opportunities
-- **[Code of Conduct](https://github.com/clouatre/math-mcp-learning-server/blob/main/CODE_OF_CONDUCT.md)**: Community guidelines and expectations
+- **[Cloud Deployment Guide](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/CLOUD_DEPLOYMENT.md)**: FastMCP Cloud deployment instructions and configuration
+- **[Usage Examples](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/EXAMPLES.md)**: Practical examples for all tools and resources
+- **[Contributing Guidelines](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md)**: Development workflow, code standards, and testing procedures
+- **[Future Improvements](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/FUTURE_IMPROVEMENTS.md)**: Roadmap and enhancement opportunities
+- **[Code of Conduct](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CODE_OF_CONDUCT.md)**: Community guidelines and expectations
 
 ## Security
 
@@ -270,7 +270,7 @@ We welcome contributions! This project follows a fast and minimal philosophy whi
 5. Run quality checks: `uv run pytest && uv run mypy src/ && uv run ruff check`
 6. Submit a pull request
 
-See [CONTRIBUTING.md](https://github.com/clouatre/math-mcp-learning-server/blob/main/CONTRIBUTING.md) for detailed guidelines including:
+See [CONTRIBUTING.md](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md) for detailed guidelines including:
 - Development workflow and Git practices
 - Code standards and security requirements
 - Testing procedures and quality assurance
@@ -278,8 +278,8 @@ See [CONTRIBUTING.md](https://github.com/clouatre/math-mcp-learning-server/blob/
 
 ## Code of Conduct
 
-This project adheres to the [Contributor Covenant Code of Conduct](https://github.com/clouatre/math-mcp-learning-server/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to hugues+mcp-coc@linux.com.
+This project adheres to the [Contributor Covenant Code of Conduct](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to hugues+mcp-coc@linux.com.
 
 ## License
 
-[MIT License](https://github.com/clouatre/math-mcp-learning-server/blob/main/LICENSE) - Full license details available in the LICENSE file.
+[MIT License](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/LICENSE) - Full license details available in the LICENSE file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.8.0"
+version = "0.8.1"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -28,15 +28,15 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/clouatre/math-mcp-learning-server"
-Repository = "https://github.com/clouatre/math-mcp-learning-server"
-Issues = "https://github.com/clouatre/math-mcp-learning-server/issues"
-Documentation = "https://github.com/clouatre/math-mcp-learning-server#readme"
-Contributing = "https://github.com/clouatre/math-mcp-learning-server/blob/main/CONTRIBUTING.md"
-"Future Improvements" = "https://github.com/clouatre/math-mcp-learning-server/blob/main/FUTURE_IMPROVEMENTS.md"
-Changelog = "https://github.com/clouatre/math-mcp-learning-server/releases"
-"Code of Conduct" = "https://github.com/clouatre/math-mcp-learning-server/blob/main/CODE_OF_CONDUCT.md"
-License = "https://github.com/clouatre/math-mcp-learning-server/blob/main/LICENSE"
+Homepage = "https://github.com/clouatre-labs/math-mcp-learning-server"
+Repository = "https://github.com/clouatre-labs/math-mcp-learning-server"
+Issues = "https://github.com/clouatre-labs/math-mcp-learning-server/issues"
+Documentation = "https://github.com/clouatre-labs/math-mcp-learning-server#readme"
+Contributing = "https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md"
+"Future Improvements" = "https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/FUTURE_IMPROVEMENTS.md"
+Changelog = "https://github.com/clouatre-labs/math-mcp-learning-server/releases"
+"Code of Conduct" = "https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CODE_OF_CONDUCT.md"
+License = "https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/LICENSE"
 
 [project.scripts]
 math-mcp-learning-server = "math_mcp.server:main"

--- a/uv.lock
+++ b/uv.lock
@@ -682,7 +682,7 @@ wheels = [
 
 [[package]]
 name = "math-mcp-learning-server"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Migration to clouatre-labs

This PR migrates the repository to the `clouatre-labs` organization to foster collaboration and maintain clear separation between personal and collaborative projects.

### Changes
- Update all GitHub URLs from `clouatre/` to `clouatre-labs/`
- Bump version to 0.8.1 (metadata update)

### Testing
- ✅ All tests passing (67/67)
- ✅ Linting clean (ruff)
- ✅ Type checking clean (mypy)
- ✅ Build successful
- ✅ Package metadata verified

### Next Steps
After merge:
1. Transfer repository to clouatre-labs
2. Configure branch protection
3. Set up PyPI Trusted Publishing environment
4. Create v0.8.1 release