### PR TITLE
fix: consolidate author identity and remove phantom contributor

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+# Consolidate all Hugues Clouâtre identities to primary email
+Hugues Clouâtre <hugues@linux.com> <15008125+huguesclouatre@users.noreply.github.com>
+Hugues Clouâtre <hugues@linux.com> <hugues.clouatre@slalom.com>
+Hugues Clouâtre <hugues@linux.com> <15008125+clouatre@users.noreply.github.com>
+Hugues Clouâtre <hugues@linux.com> <hugues+mcp@linux.com>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11,<3.14"
 license = "MIT"
 authors = [
-    {name = "Hugues Clouâtre", email = "hugues+mcp@linux.com"}
+    {name = "Hugues Clouâtre", email = "hugues@linux.com"}
 ]
 keywords = ["mcp", "math", "calculator", "learning", "fastmcp", "tutorial", "education", "cloud", "deployment", "workspace", "persistence"]
 classifiers = [


### PR DESCRIPTION
## Problem
GitHub web UI shows phantom "claude" as a contributor despite:
- API correctly shows only clouatre and dependabot
- No commits from claude user
- All commits authored by Hugues Clouâtre

## Solution
1. **Add .mailmap** - Consolidates all email identities to canonical `hugues@linux.com`
   - Maps GitHub noreply addresses
   - Maps work email (hugues.clouatre@slalom.com)
   - Maps email alias (hugues+mcp@linux.com)

2. **Update pyproject.toml** - Use primary email instead of alias
   - Changed from `hugues+mcp@linux.com` → `hugues@linux.com`

## Expected Result
- GitHub contributor graph should recalculate
- Phantom "claude" entry should disappear
- All contributions shown under single identity

## Evidence
```bash
git shortlog -sne  # Now shows single identity
gh api repos/clouatre-labs/math-mcp-learning-server/contributors  # API already correct
```

## References
- Standard practice (used by Linux, React, Node.js)
- No history rewrite (commits unchanged)
- Addresses issue persisting for weeks