### PR TITLE
chore: update gitignore for .kiro and internal planning folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,10 @@ opencode.json
 .codex/
 .cursor/
 .windsurf/
+.kiro/
+
+# Internal planning & analysis (not committed)
+internal/
 
 # IDEs & editors
 .vscode/


### PR DESCRIPTION
- Add .kiro/ to coding agents section (Kiro AI agent)
- Add internal/ folder for local planning docs (not committed to repo)

Both folders contain local tooling/analysis that shouldn't be in version control.