### PR TITLE
ci: add merge_group trigger to support GitHub merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     branches: [ main ]
     paths-ignore:
       - 'docs/**/*.md'
+  merge_group:
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Enable CI validation for merge queue temporary branches.

## What Changed
- Added `merge_group` event trigger to `.github/workflows/ci.yml`
- Allows GitHub Actions to validate code when added to merge queue
- CI now runs lint, security, and test jobs on temporary `gh-readonly-queue/main` branches

## Why This Matters
Merge queue validates PRs against the latest `main` branch state, preventing integration issues:
- Two PRs might pass tests individually but fail together
- Catches this before merge (solves PR #67/#68 duplicate commit incident)
- Enables automation: developers add PR to queue → GitHub auto-merges when safe

## Next Steps
After this PR merges:
1. Enable 'Require merge queue' in branch protection rule (web UI)
2. Configure: merge method=squash, timeout=10min, max entries=1
3. Test: Create PR, click 'Add to merge queue', watch auto-merge

Related: Implements GitHub merge queue support for automation