### PR TITLE
chore(deploy): sync fastmcp.json dependencies with pyproject.toml

### DIFF
--- a/fastmcp.json
+++ b/fastmcp.json
@@ -10,9 +10,10 @@
     "python": ">=3.11",
     "dependencies": [
       "fastmcp>=2.0.0",
-      "pydantic>=2.11.9",
-      "matplotlib>=3.8.0",
-      "numpy>=1.26.0"
+      "pydantic>=2.12.0",
+      "pydantic-settings>=2.0.0",
+      "matplotlib>=3.10.6",
+      "numpy>=2.3.3"
     ],
     "vars": {
       "PYTHONPATH": "src"


### PR DESCRIPTION
## Sync Cloud Deployment Dependencies

**Problem:**
FastMCP Cloud deployment is stuck on November 4th version (pre-v0.9.0), missing critical production features added in recent releases.

**Root Cause:**
- Cloud auto-redeploy monitoring may not be active
- Dependencies in `fastmcp.json` were outdated and didn't match `pyproject.toml`

**Solution:**
Update `fastmcp.json` dependencies to match current `pyproject.toml` versions:

### Dependency Updates
- `pydantic`: 2.11.9 → 2.12.0
- `pydantic-settings`: Added (was missing, required by server)
- `matplotlib`: 3.8.0 → 3.10.6
- `numpy`: 1.26.0 → 2.3.3

### Benefits
- Cloud builds use same dependency versions as local development
- Reduces "works locally but not in cloud" issues
- Ensures cloud deployment has latest production features from v0.9.0

### Testing
- [x] JSON validation passed
- [x] All 105 tests passing locally
- [x] No breaking changes

### Post-Merge Action Required
After merging, **manually trigger redeploy** in FastMCP Cloud dashboard if auto-deploy doesn't activate:
1. Visit https://fastmcp.cloud
2. Find math-mcp-learning-server project
3. Click "Redeploy" or "Rebuild" button

This ensures cloud deployment includes all v0.9.0 production features (rate limiting, input validation, security hardening, etc.).