### PR TITLE
test: trigger FastMCP Cloud deployment

### DIFF
--- a/fastmcp.json
+++ b/fastmcp.json
@@ -22,5 +22,8 @@
   "deployment": {
     "transport": "http",
     "log_level": "INFO"
+  },
+  "metadata": {
+    "updated": "2025-12-10"
   }
 }


### PR DESCRIPTION
Test if FastMCP Cloud auto-deploy works after granting organization access.

This adds a harmless metadata field to fastmcp.json to trigger deployment.

**Expected:**
- FastMCP Cloud should build and deploy a preview for this PR
- Preview URL should be available

**If this works:**
- Auto-deploy is restored
- We can revert this change and everything is fixed

**If this doesn't work:**
- Need to manually configure project in FastMCP Cloud dashboard