### PR TITLE
docs: update cloud URL to math-mcp.fastmcp.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Connect your MCP client to the hosted server:
   "mcpServers": {
     "math-cloud": {
       "transport": "http",
-      "url": "https://math-mcp-learning.fastmcp.app/mcp"
+      "url": "https://math-mcp.fastmcp.app/mcp"
     }
   }
 }

--- a/docs/CLOUD_DEPLOYMENT.md
+++ b/docs/CLOUD_DEPLOYMENT.md
@@ -37,7 +37,7 @@ This server includes a `fastmcp.json` configuration file for seamless cloud depl
 1. **Navigate to**: [FastMCP Cloud Dashboard](https://fastmcp.cloud)
 2. **Connect GitHub Repository**: `clouatre-labs/math-mcp-learning-server`
 3. **Deploy**: FastMCP Cloud auto-detects `fastmcp.json` configuration
-4. **Access via MCP Client**: Connect your MCP client to `https://math-mcp-learning.fastmcp.app/mcp`
+4. **Access via MCP Client**: Connect your MCP client to `https://math-mcp.fastmcp.app/mcp`
 
 ### Cloud Storage Considerations
 


### PR DESCRIPTION
Updates FastMCP Cloud URL after creating new deployment with simpler project name.

## Changes
- **README.md**: Update cloud connection URL
- **docs/CLOUD_DEPLOYMENT.md**: Update deployment URL

## Context
- Old URL: `https://math-mcp-learning.fastmcp.app/mcp` (broken after org transfer)
- New URL: `https://math-mcp.fastmcp.app/mcp` (fresh deployment, working)

## Background
Repository was transferred from `clouatre/` to `clouatre-labs/` organization on Nov 4, 2025. This broke FastMCP Cloud auto-deploy because the GitHub App didn't have access to organization repos. After granting access, created new deployment with simpler name.