### PR TITLE
feat: add MCP Registry support and submission guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![CI](https://github.com/clouatre-labs/math-mcp-learning-server/actions/workflows/ci.yml/badge.svg)](https://github.com/clouatre-labs/math-mcp-learning-server/actions/workflows/ci.yml)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
+<!-- mcp-name: io.github.clouatre-labs/math-mcp-learning-server -->
+
 Educational MCP server demonstrating persistent workspace patterns and mathematical operations. Built with [FastMCP 2.0](https://github.com/jlowin/fastmcp) and the official [Model Context Protocol Python SDK](https://github.com/modelcontextprotocol/python-sdk).
 
 ## Requirements

--- a/docs/SUBMISSION_GUIDE.md
+++ b/docs/SUBMISSION_GUIDE.md
@@ -1,0 +1,82 @@
+# MCP Server Publication Guide
+
+Educational MCP server with 12 math/stats tools, persistent workspace, and cloud hosting. Demonstrates FastMCP 2.0 best practices with 86% test coverage.
+
+**Links:** [PyPI](https://pypi.org/project/math-mcp-learning-server/) | [Cloud](https://math-mcp.fastmcp.app/mcp) | [GitHub](https://github.com/clouatre-labs/math-mcp-learning-server)
+
+---
+
+## Official MCP Registry
+
+**URL:** https://registry.modelcontextprotocol.io/  
+**Docs:** https://github.com/modelcontextprotocol/registry/tree/main/docs
+
+```bash
+# Install CLI
+brew install mcp-publisher
+
+# Authenticate
+mcp-publisher login github
+
+# Publish (requires server.json in repo root)
+mcp-publisher publish
+
+# Verify
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.clouatre-labs/math-mcp-learning-server"
+```
+
+**Requirements:**
+- PyPI package published
+- `<!-- mcp-name: io.github.clouatre-labs/math-mcp-learning-server -->` in README.md
+- `server.json` in repository root (see repo for template)
+
+---
+
+## Community Registries
+
+### modelcontextprotocol/servers
+**URL:** https://github.com/modelcontextprotocol/servers  
+**Method:** Pull Request to README
+
+```markdown
+- **[Math MCP Learning](https://github.com/clouatre-labs/math-mcp-learning-server)** - Educational MCP with 12 math/stats tools, persistent workspace, cloud hosting. Demonstrates FastMCP 2.0 best practices.
+```
+
+### Awesome MCP Servers
+**URL:** https://github.com/mctrinh/awesome-mcp-servers  
+**Method:** Pull Request
+
+### Awesome Remote MCP Servers
+**URL:** https://github.com/sylviangth/awesome-remote-mcp-servers  
+**Method:** Pull Request (cloud-focused)
+
+### FastMCP Showcase
+**URL:** https://github.com/jlowin/fastmcp/blob/main/docs/community/showcase.mdx  
+**Method:** Pull Request to `docs/community/showcase.mdx`
+
+### ToolSDK MCP Registry
+**URL:** https://github.com/toolsdk-ai/toolsdk-mcp-registry  
+**Method:** Check repository for submission process
+
+---
+
+## Social
+
+**Reddit:** r/LLM, r/LocalLLaMA, r/ClaudeAI  
+**Discord:** [FastMCP](https://discord.com/invite/aGsSC3yDF4)  
+**X/Twitter:** #MCP hashtag
+
+---
+
+## Status
+
+| Platform | Status | Date | Notes |
+|----------|--------|------|-------|
+| Official MCP Registry | 🔧 Ready | 2025-12-10 | Files prepared |
+| AWSome MCP | ✅ Done | 2025-12-10 | Form submitted |
+| Community MCP Servers | ⏳ Pending | - | PR needed |
+| Awesome Remote MCP | ⏳ Pending | - | PR needed |
+| FastMCP Showcase | ⏳ Pending | - | PR needed |
+| ToolSDK Registry | ⏳ Pending | - | Check process |
+| Awesome MCP Servers | ⏳ Pending | - | PR needed |
+

--- a/server.json
+++ b/server.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.clouatre-labs/math-mcp-learning-server",
+  "title": "Math MCP Learning",
+  "description": "Educational MCP server with math operations, statistics, visualizations, and persistent workspace. Demonstrates FastMCP 2.0 best practices.",
+  "repository": {
+    "url": "https://github.com/clouatre-labs/math-mcp-learning-server",
+    "source": "github"
+  },
+  "version": "0.9.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "math-mcp-learning-server",
+      "version": "0.9.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "remotes": [
+    {
+      "type": "sse",
+      "url": "https://math-mcp.fastmcp.app/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Prepares the repository for submission to the Official MCP Registry (https://registry.modelcontextprotocol.io/).

## Changes

- **README.md**: Added MCP verification string `<!-- mcp-name: io.github.clouatre-labs/math-mcp-learning-server -->`
- **server.json**: Created MCP Registry configuration with:
  - Server name: `io.github.clouatre-labs/math-mcp-learning-server`
  - PyPI package transport (stdio)
  - FastMCP Cloud remote transport (SSE)
- **docs/SUBMISSION_GUIDE.md**: Added concise submission guide with:
  - Official MCP Registry instructions
  - Community registry links
  - Social media channels
  - Submission tracking table

## Verification

All files use consistent naming:
- Server name matches repository name for discoverability
- FastMCP Cloud URL verified: https://math-mcp.fastmcp.app/mcp
- PyPI package already published: v0.9.0

## Next Steps

After merge:
1. Install `mcp-publisher` CLI
2. Authenticate with GitHub OAuth
3. Run `mcp-publisher publish`
4. Verify publication at registry.modelcontextprotocol.io