### PR TITLE
chore: bump version to 0.9.1 for MCP Registry publication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.9.0"
+version = "0.9.1"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -2,17 +2,17 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.clouatre-labs/math-mcp-learning-server",
   "title": "Math MCP Learning",
-  "description": "Educational MCP server with math operations, statistics, visualizations, and persistent workspace. Demonstrates FastMCP 2.0 best practices.",
+  "description": "Educational MCP server with 12 math/stats tools, visualizations, and persistent workspace",
   "repository": {
     "url": "https://github.com/clouatre-labs/math-mcp-learning-server",
     "source": "github"
   },
-  "version": "0.9.0",
+  "version": "0.9.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "math-mcp-learning-server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Patch release to enable MCP Registry publication. Updates version to 0.9.1 in pyproject.toml and server.json. README already contains MCP verification string from PR 96.