### PR TITLE
fix: use streamable-http instead of deprecated sse transport

### DIFF
--- a/server.json
+++ b/server.json
@@ -20,7 +20,7 @@
   ],
   "remotes": [
     {
-      "type": "sse",
+      "type": "streamable-http",
       "url": "https://math-mcp.fastmcp.app/mcp"
     }
   ]


### PR DESCRIPTION
Corrects remote transport type from deprecated SSE to recommended streamable-http. FastMCP Cloud uses HTTP transport, not SSE.