### PR TITLE
feat(deps): add [scientific] extra with numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ plotting = [
     "matplotlib>=3.10.6",
     "numpy>=2.3.3",
 ]
+scientific = [
+    "numpy>=2.3.3",
+]
 
 [tool.ruff]
 target-version = "py314"


### PR DESCRIPTION
## Summary

Add optional `[scientific]` dependency group with numpy to support upcoming matrix operations (Phase 4 of ROADMAP.md).

## Changes

- Add `[project.optional-dependencies.scientific]` section to `pyproject.toml`
- Include `numpy>=2.3.3` for matrix operations
- Matches version from `[plotting]` extra for consistency

## Installation

Users who need matrix operations can install:
```bash
uv pip install math-mcp-learning-server[scientific]
```

Or for development:
```bash
git clone https://github.com/clouatre-labs/math-mcp-learning-server
cd math-mcp-learning-server
uv sync --extra scientific
```

## Testing

- pyproject.toml syntax valid
- `uv pip install -e ".[scientific]"` succeeds
- `import numpy` works
- Existing tests pass

## Rationale

This prepares the dependency structure for Phase 4 matrix operations as outlined in ROADMAP.md. The `[scientific]` extra is independent of `[plotting]`, allowing users to install matrix capabilities without visualization dependencies.

Matrix operations will be implemented in subsequent PRs.

## Checklist

- [x] Follows existing dependency patterns
- [x] Uses version constraints matching `[plotting]` extra
- [x] Optional dependency (doesn't force numpy on all users)
- [x] Conventional commit message
- [x] Tests pass
- [x] Installation verified