### PR TITLE
chore: release v0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.9.2"
+version = "0.10.0"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ wheels = [
 
 [[package]]
 name = "math-mcp-learning-server"
-version = "0.9.2"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Release v0.10.0 - Matrix Operations

Version bump for v0.10.0 release.

This release includes Phase 4 matrix operations (PRs #106, #108, #109, #110).

**Changes:**
- Bump version: 0.9.2 → 0.10.0
- Update uv.lock

**After merge:**
- Create git tag v0.10.0
- Create GitHub release with full changelog
- PyPI auto-publish via GitHub Actions

See full release notes in the upcoming GitHub release.