### PR TITLE
docs: fix markdown line breaks in validation report

### DIFF
--- a/docs/testing/reports/v0.10.0-validation.md
+++ b/docs/testing/reports/v0.10.0-validation.md
@@ -1,9 +1,9 @@
 # MATH-MCP-LEARNING-SERVER v0.10.0 - COMPREHENSIVE QA TEST REPORT
 
-**Test Date:** December 13, 2025
-**Version Tested:** 0.10.0
-**Test Execution Time:** ~35 seconds
-**Test Framework:** pytest with asyncio support
+**Test Date:** December 13, 2025  
+**Version Tested:** 0.10.0  
+**Test Execution Time:** ~35 seconds  
+**Test Framework:** pytest with asyncio support  
 
 ---
 
@@ -293,10 +293,11 @@ Tools Discovered: 17
 ## Known Gaps & Future Work
 
 ### Coverage Gaps (To address in v0.11.0)
-⚠️ **MCP Resources:** Not explicitly tested (5 resources)
-⚠️ **MCP Prompts:** Not explicitly tested (2 prompts)
-⚠️ **Integration workflows:** No end-to-end workflow tests
-⚠️ **Performance benchmarks:** No systematic benchmarks
+
+- ⚠️ **MCP Resources:** Not explicitly tested (5 resources)  
+- ⚠️ **MCP Prompts:** Not explicitly tested (2 prompts)  
+- ⚠️ **Integration workflows:** No end-to-end workflow tests  
+- ⚠️ **Performance benchmarks:** No systematic benchmarks  
 
 See [coverage-gaps.md](../coverage-gaps.md) for detailed roadmap.
 
@@ -335,6 +336,6 @@ See [coverage-gaps.md](../coverage-gaps.md) for detailed roadmap.
 
 ---
 
-**Report Generated:** December 13, 2025, 16:44 UTC
-**Report Version:** 1.0
-**Next Review:** v0.11.0 release
+**Report Generated:** December 13, 2025, 16:44 UTC  
+**Report Version:** 1.0  
+**Next Review:** v0.11.0 release  


### PR DESCRIPTION
## Summary
Fixes Markdown formatting in the v0.10.0 validation report to ensure proper line breaks.

## Changes
Added trailing double spaces (Markdown line break syntax) to three sections:

### 1. Header Metadata (Lines 3-6)
- Test Date
- Version Tested  
- Test Execution Time
- Test Framework

### 2. Coverage Gaps List (Lines 295-299)
- Converted to bullet list with proper line breaks
- Added blank line after heading
- Each item now has trailing double spaces

### 3. Footer Section (Lines 338-340)
- Report Generated
- Report Version
- Next Review

## Impact
**Before:** Metadata and footer render as single lines in some Markdown viewers  
**After:** Proper multi-line rendering in all Markdown viewers

## Testing
- ✅ Verified trailing spaces present (2 spaces at EOL)
- ✅ Verified bullet list formatting
- ✅ No functional changes (documentation only)

## Related
Follow-up to PR #112 (merged)