### PR TITLE
fix: add MCP Registry auto-publish to CI/CD workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -65,3 +65,29 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  mcp-registry:
+    name: Publish to MCP Registry
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Sync version from release tag to server.json
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > tmp.json && mv tmp.json server.json
+          cat server.json
+
+      - name: Install MCP Publisher
+        run: |
+          curl -sSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.1.0/mcp-publisher_1.1.0_linux_amd64.tar.gz" | tar xz mcp-publisher
+
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Educational MCP server demonstrating persistent workspace patterns and mathemati
 **Available on:**
 - [Official MCP Registry](https://registry.modelcontextprotocol.io/) - `io.github.clouatre-labs/math-mcp-learning-server`
 - [PyPI](https://pypi.org/project/math-mcp-learning-server/) - `math-mcp-learning-server`
-- [FastMCP Cloud](https://math-mcp.fastmcp.app/mcp) - No installation required
+- [FastMCP Cloud](https://fastmcp.cloud/app/math-mcp) - No installation required
 
 ## Requirements
 

--- a/server.json
+++ b/server.json
@@ -2,17 +2,17 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.clouatre-labs/math-mcp-learning-server",
   "title": "Math MCP Learning",
-  "description": "Educational MCP server with 12 math/stats tools, visualizations, and persistent workspace",
+  "description": "Educational MCP server with 17 math/stats tools, visualizations, and persistent workspace",
   "repository": {
     "url": "https://github.com/clouatre-labs/math-mcp-learning-server",
     "source": "github"
   },
-  "version": "0.9.2",
+  "version": "0.10.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "math-mcp-learning-server",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Add automated MCP Registry publishing after PyPI releases.

## Changes

- Add `mcp-registry` job to `python-publish.yml` (runs after PyPI publish succeeds)
- Auto-sync version from release tag to `server.json`
- Use SHA-pinned `actions/checkout` for consistency with other jobs
- Pin `mcp-publisher` CLI to v1.1.0
- Update README FastMCP Cloud URL to landing page (`https://fastmcp.cloud/app/math-mcp`)
- Bump `server.json` to 0.10.0 with 17 tools description

## Why

The MCP Registry was stuck at v0.9.1 because publishing was manual. This automates the process so future releases are automatically published to both PyPI and MCP Registry.

## Testing

- [x] ruff check passed
- [x] ruff format passed
- [x] 126 tests passed
- [x] actionlint passed