### PR TITLE
release: bump version to 0.10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.10.0"
+version = "0.10.1"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/clouatre-labs/math-mcp-learning-server",
     "source": "github"
   },
-  "version": "0.10.0",
+  "version": "0.10.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "math-mcp-learning-server",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Bump version to 0.10.1 for patch release.

## Changes

- `pyproject.toml`: 0.10.0 → 0.10.1
- `server.json`: 0.10.0 → 0.10.1

## Why

- README FastMCP Cloud URL fix (from PR #115)
- CI/CD MCP Registry auto-publish (from PR #115)
- Dependency updates for artifact actions (from PR #114)

## After Merge

Create release v0.10.1 to trigger CI/CD:
1. PyPI publish
2. MCP Registry publish (new)