### PR TITLE
fix: update MCP Registry schema to 2025-12-11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.10.1"
+version = "0.10.2"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.clouatre-labs/math-mcp-learning-server",
   "title": "Math MCP Learning",
   "description": "Educational MCP server with 17 math/stats tools, visualizations, and persistent workspace",
@@ -7,12 +7,12 @@
     "url": "https://github.com/clouatre-labs/math-mcp-learning-server",
     "source": "github"
   },
-  "version": "0.10.1",
+  "version": "0.10.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "math-mcp-learning-server",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ wheels = [
 
 [[package]]
 name = "math-mcp-learning-server"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Updates deprecated MCP Registry schema `2025-10-17` to current `2025-12-11`.

## Changes

- `server.json`: schema version `2025-10-17` -> `2025-12-11`
- `pyproject.toml`: version `0.10.1` -> `0.10.2`
- `server.json`: version `0.10.1` -> `0.10.2`

## Why

mcp-publisher CLI v1.1.0 rejects `2025-10-17` as deprecated. The `2025-12-11` schema is confirmed current per MCP Registry CHANGELOG.