### PR TITLE
fix: fetch latest mcp-publisher version dynamically

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -84,7 +84,10 @@ jobs:
 
       - name: Install MCP Publisher
         run: |
-          curl -sSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.1.0/mcp-publisher_1.1.0_linux_amd64.tar.gz" | tar xz mcp-publisher
+          VERSION=$(curl -sI https://github.com/modelcontextprotocol/registry/releases/latest | grep -i '^location:' | sed 's/.*tag\///' | tr -d '\r\n')
+          echo "Installing mcp-publisher ${VERSION}"
+          curl -sSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher --version
 
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.10.2"
+version = "0.10.3"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/clouatre-labs/math-mcp-learning-server",
     "source": "github"
   },
-  "version": "0.10.2",
+  "version": "0.10.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "math-mcp-learning-server",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ wheels = [
 
 [[package]]
 name = "math-mcp-learning-server"
-version = "0.10.1"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Fixes MCP Registry publish workflow by dynamically fetching the latest mcp-publisher version instead of hardcoding v1.1.0.

## Problem

The hardcoded v1.1.0 URL no longer works - mcp-publisher changed their asset naming convention and v1.4.0 was released today.

## Changes

- Fetches latest release tag from GitHub API
- Uses new asset naming format (`mcp-publisher_linux_amd64.tar.gz` without version number)
- Prints version for debugging

## Testing

Tested in Ubuntu container matching GitHub Actions environment:
```
VERSION: v1.4.0
mcp-publisher 1.4.0 (commit: 731198572b929b9d98894ff69fa42b345b78e4e1)
```

**Full Changelog**: https://github.com/clouatre-labs/math-mcp-learning-server/compare/v0.10.2...HEAD