### PR TITLE
docs: fix FastMCP Cloud URL

### DIFF
--- a/FUTURE_IMPROVEMENTS.md
+++ b/FUTURE_IMPROVEMENTS.md
@@ -9,7 +9,7 @@ This project follows **FastMCP 2.0 best practices**:
 - **Optional features**: Defined in `[project.optional-dependencies]` for plotting, etc.
 - **Production**: Install via PyPI with optional groups: `uv pip install math-mcp-learning-server[plotting]`
 - **Development**: `uv sync --all-extras` for all optional dependencies
-- **Cloud deployment**: Automatic via FastMCP Cloud (https://math-mcp-learning.fastmcp.app/mcp)
+- **Cloud deployment**: Automatic via FastMCP Cloud (https://math-mcp.fastmcp.app/mcp)
 
 ## 🔌 **MCP Client Requirement**
 
@@ -92,7 +92,7 @@ get_workspace()  # Shows all saved calculations
 - ✅ **Unified workspace file** (`~/.math-mcp/workspace.json`) across all transports
 
 #### **1.3 FastMCP Cloud Deployment ✅ COMPLETE**
-- ✅ **Cloud hosting at https://math-mcp-learning.fastmcp.app/mcp**
+- ✅ **Cloud hosting at https://math-mcp.fastmcp.app/mcp**
 - ✅ **Automatic environment-based authentication** (OAuth, JWT via env vars)
 - ✅ **Production transport support** (SSE, HTTP)
 - ✅ **Zero-config deployment** from GitHub repository
@@ -290,7 +290,7 @@ uv run fastmcp dev src/math_mcp/server.py
 # Then connect via MCP client (Claude Desktop, Claude Code, OpenCode, etc.)
 
 # Cloud deployment:
-# Visit https://math-mcp-learning.fastmcp.app/mcp
+# Visit https://math-mcp.fastmcp.app/mcp
 # Or deploy your own via FastMCP Cloud
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/math-mcp-learning-server.svg)](https://pypi.org/project/math-mcp-learning-server/)
 [![CI](https://github.com/clouatre-labs/math-mcp-learning-server/actions/workflows/ci.yml/badge.svg)](https://github.com/clouatre-labs/math-mcp-learning-server/actions/workflows/ci.yml)
 
-**Cloud hosted:** Connect any MCP client to [https://math-mcp-learning.fastmcp.app/mcp](https://math-mcp-learning.fastmcp.app/mcp) (MCP client required, no local server install needed)
+**Cloud hosted:** Connect any MCP client to [https://math-mcp.fastmcp.app/mcp](https://math-mcp.fastmcp.app/mcp) (MCP client required, no local server install needed)
 
 A persistent quantitative workspace built as a Model Context Protocol (MCP) server. This project demonstrates enterprise-grade patterns for MCP development, featuring cross-session state persistence - a unique capability that most LLMs cannot achieve natively.
 
@@ -37,7 +37,7 @@ Connect your MCP client to the hosted server - no local installation required!
   "mcpServers": {
     "math-cloud": {
       "transport": "http",
-      "url": "https://math-mcp-learning.fastmcp.app/mcp"
+      "url": "https://math-mcp.fastmcp.app/mcp"
     }
   }
 }
@@ -45,7 +45,7 @@ Connect your MCP client to the hosted server - no local installation required!
 
 **Claude Code:**
 ```bash
-claude mcp add math-cloud https://math-mcp-learning.fastmcp.app/mcp
+claude mcp add math-cloud https://math-mcp.fastmcp.app/mcp
 ```
 
 ### Option 2: Run Locally

--- a/docs/CLOUD_DEPLOYMENT.md
+++ b/docs/CLOUD_DEPLOYMENT.md
@@ -37,7 +37,7 @@ This server includes a `fastmcp.json` configuration file for seamless cloud depl
 1. **Navigate to**: [FastMCP Cloud Dashboard](https://fastmcp.cloud)
 2. **Connect GitHub Repository**: `clouatre-labs/math-mcp-learning-server`
 3. **Deploy**: FastMCP Cloud auto-detects `fastmcp.json` configuration
-4. **Access via MCP Client**: Connect your MCP client to `https://math-mcp-learning.fastmcp.app/mcp`
+4. **Access via MCP Client**: Connect your MCP client to `https://math-mcp.fastmcp.app/mcp`
 
 ### Cloud Storage Considerations
 


### PR DESCRIPTION
## Summary

Fix incorrect FastMCP Cloud URL in documentation.

## Problem

The documentation referenced `https://math-mcp-learning.fastmcp.app/mcp` which returns 404 errors. The correct URL is `https://math-mcp.fastmcp.app/mcp`.

## Changes

Updated 7 URL references across 3 files:
- `README.md` (3 occurrences)
- `docs/CLOUD_DEPLOYMENT.md` (1 occurrence)
- `FUTURE_IMPROVEMENTS.md` (3 occurrences)

## Testing

Verified the correct endpoint responds:
```bash
curl -X POST https://math-mcp.fastmcp.app/mcp \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", ...}'
# Returns: Math Learning Server v1.25.0
```