### PR TITLE
fix: pin ruff to <0.15.0 to work around formatting regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,13 @@ jobs:
     - name: Ruff check
       uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
       with:
+        version: '>=0.13.1,<0.15.0'
         args: 'check'
     
     - name: Ruff format
       uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
       with:
+        version: '>=0.13.1,<0.15.0'
         args: 'format --check'
 
   security:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,10 @@ dev = [
     "pytest>=8.4.2",
     "pytest-asyncio>=0.25.2",
     "pytest-cov>=4.0.0",
-    "ruff>=0.13.1",
+    # Pin ruff <0.15.0 to work around formatting regression in 0.15.0 that removes
+    # parentheses from multi-exception except clauses. Remove this constraint when
+    # ruff 0.15.1+ is released with the fix.
+    "ruff>=0.13.1,<0.15.0",
 ]
 plotting = [
     "matplotlib>=3.10.6",

--- a/uv.lock
+++ b/uv.lock
@@ -948,7 +948,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25.2" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.1,<0.15.0" },
 ]
 provides-extras = ["dev", "plotting", "scientific"]
 


### PR DESCRIPTION
## Summary

Pin ruff to `<0.15.0` in both `pyproject.toml` (dev dependency) and CI workflow (`ruff-action` version parameter) to work around a formatting regression in ruff 0.15.0 that removes parentheses from multi-exception except clauses, producing invalid Python 3 syntax.

## Root Cause

ruff 0.15.0 implements PEP 758 behavior that converts `except (OSError, PermissionError):` to `except OSError, PermissionError:` when `target-version >= py314`. The unparenthesized form is invalid Python 3 syntax (`SyntaxError: multiple exception types must be parenthesized`).

## Changes

- **pyproject.toml**: `ruff>=0.13.1` -> `ruff>=0.13.1,<0.15.0` with inline comment explaining the pin
- **.github/workflows/ci.yml**: Added `version: '>=0.13.1,<0.15.0'` to both `ruff-action` steps (the action bundles its own ruff binary, so the pyproject.toml pin alone does not fix CI)
- **uv.lock**: Updated lockfile specifier

## Testing

- `uv run ruff format --check src/ tests/` -- PASS
- `uv run ruff check src/ tests/` -- PASS
- `uv run pytest -v` -- 126/126 passed

## Removal Plan

Remove the `<0.15.0` constraint when ruff 0.15.1+ ships with the fix.

Closes #127