### PR TITLE
ci: disable merge queue

### DIFF
--- a/.github/MAINTAINER_GUIDE.md
+++ b/.github/MAINTAINER_GUIDE.md
@@ -144,6 +144,10 @@ Key points for maintainers:
 - Ensure test coverage remains above 80%
 - Document breaking changes clearly
 
+## Merge Queue
+
+Disabled (PR #130). Unnecessary overhead for a small project. To re-enable, see PR #71 for the original implementation.
+
 ---
 
 For questions, open an issue or contact the project maintainers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
     branches: [ main ]
     paths-ignore:
       - 'docs/**/*.md'
-  merge_group:
-    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Disable merge queue -- unnecessary overhead for a small project.

## Changes

- Removed `merge_group` trigger from CI workflow (2 lines)
- Removed `merge_queue` rule from GitHub ruleset (ID: 10860043) via API; all other rules preserved
- Added one-liner to MAINTAINER_GUIDE.md pointing to PR #71 for re-enabling