### PR TITLE
chore: automerge patch, minor, digest, and pin dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,10 @@
   "packageRules": [
     {
       "matchUpdateTypes": [
-        "patch"
+        "patch",
+        "minor",
+        "digest",
+        "pin"
       ],
       "automerge": true
     },


### PR DESCRIPTION
Expand Renovate automerge rule to cover minor, digest, and pin update types in addition to patch.

This avoids manual merges for low-risk dependency updates like ruff minor bumps (e.g., PR #129). The `minimumReleaseAge: 3 days` and CI checks still gate all merges.

**Changes:**
- `renovate.json`: Added `minor`, `digest`, `pin` to the automerge `matchUpdateTypes` rule

Only `major` updates will now require manual review.