### PR TITLE
ci: skip CI for docs-only and license changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - 'docs/**/*.md'
+      - '**/*.md'
+      - 'LICENSE'
+      - 'docs/**'
   pull_request:
     branches: [ main ]
     paths-ignore:
-      - 'docs/**/*.md'
+      - '**/*.md'
+      - 'LICENSE'
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Expand `paths-ignore` to skip the entire CI workflow when a PR only touches documentation or license files.

**Before:** Only `docs/**/*.md` was ignored, so root-level markdown changes (ROADMAP.md, README.md, CONTRIBUTING.md, etc.) still triggered lint, test, and security jobs unnecessarily.

**After:** CI is skipped for changes that only touch:
- `**/*.md` -- all markdown files (root and nested)
- `LICENSE`
- `docs/**` -- all docs directory content (not just .md)

Any PR that also modifies code, config, or workflow files still triggers the full pipeline.

Ref: PR #126 (docs-only) triggered the full test matrix unnecessarily.