### PR TITLE
docs: update FastMCP Cloud references to Prefect Horizon

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Educational MCP server demonstrating persistent workspace patterns and mathemati
 **Available on:**
 - [Official MCP Registry](https://registry.modelcontextprotocol.io/) - `io.github.clouatre-labs/math-mcp-learning-server`
 - [PyPI](https://pypi.org/project/math-mcp-learning-server/) - `math-mcp-learning-server`
-- [FastMCP Cloud](https://fastmcp.cloud/app/math-mcp) - No installation required
+- [Prefect Horizon](https://horizon.prefect.io/app/math-mcp) - No installation required
 
 ## Requirements
 
@@ -198,7 +198,7 @@ See [CONTRIBUTING.md](https://github.com/clouatre-labs/math-mcp-learning-server/
 
 ## Documentation
 
-- **[Cloud Deployment Guide](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/CLOUD_DEPLOYMENT.md)**: FastMCP Cloud deployment instructions and configuration
+- **[Cloud Deployment Guide](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/CLOUD_DEPLOYMENT.md)**: Prefect Horizon deployment instructions and configuration
 - **[Usage Examples](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/EXAMPLES.md)**: Practical examples for all tools and resources
 - **[Contributing Guidelines](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md)**: Development workflow, code standards, and testing procedures
 - **[Roadmap](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/ROADMAP.md)**: Planned features and enhancement opportunities

--- a/docs/CLOUD_DEPLOYMENT.md
+++ b/docs/CLOUD_DEPLOYMENT.md
@@ -1,8 +1,8 @@
 # Cloud Deployment Guide
 
-## FastMCP Cloud Deployment
+## Prefect Horizon Deployment
 
-Deploy this server to [FastMCP Cloud](https://fastmcp.cloud) for hosted, production-ready access without local setup.
+Deploy this server to [Prefect Horizon](https://horizon.prefect.io) for hosted, production-ready access without local setup.
 
 ### Deployment Configuration
 
@@ -32,11 +32,11 @@ This server includes a `fastmcp.json` configuration file for seamless cloud depl
 }
 ```
 
-### Deploy to FastMCP Cloud
+### Deploy to Prefect Horizon
 
-1. **Navigate to**: [FastMCP Cloud Dashboard](https://fastmcp.cloud)
+1. **Navigate to**: [Prefect Horizon Dashboard](https://horizon.prefect.io)
 2. **Connect GitHub Repository**: `clouatre-labs/math-mcp-learning-server`
-3. **Deploy**: FastMCP Cloud auto-detects `fastmcp.json` configuration
+3. **Deploy**: Prefect Horizon auto-detects `fastmcp.json` configuration
 4. **Access via MCP Client**: Connect your MCP client to `https://math-mcp.fastmcp.app/mcp`
 
 ### Cloud Storage Considerations


### PR DESCRIPTION
## Summary

FastMCP Cloud has been rebranded as **Prefect Horizon** ([horizon.prefect.io](https://horizon.prefect.io)). This PR updates all dashboard links and platform name references in documentation.

## Changes

- **README.md**: Update "Available on" link and Documentation section description
- **docs/CLOUD_DEPLOYMENT.md**: Update headings, dashboard links, and platform name references

## What is NOT changed

- MCP endpoint URL (`https://math-mcp.fastmcp.app/mcp`) -- still live and correct
- `fastmcp.json` configuration -- format and schema unchanged
- Cloud Deployment Guide content -- still teaches students how to deploy MCP servers
- `"math-cloud"` server name in Claude Desktop config example

## Context

Prefect acquired FastMCP and graduated FastMCP Cloud into [Prefect Horizon](https://www.prefect.io/blog/prefect-horizon). The free personal hosting tier is preserved. The `*.fastmcp.app` serving domain remains operational.