### PR TITLE
docs: add branch cleanup guidance to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,13 @@ ROADMAP.md                # Ideas for later consideration
    - Summary of testing performed
    - Note any breaking changes
 
+### Branch Cleanup
+When closing a PR without merging, please delete your remote branch to keep the repository clean:
+```bash
+git push origin --delete your-branch-name
+```
+Merged PRs automatically delete their branches due to the repository's `delete_branch_on_merge` setting, so no manual cleanup is needed for merged changes.
+
 ### PR Review
 - Automated checks must pass
 - Code review by maintainers


### PR DESCRIPTION
## Summary

Add a Branch Cleanup section to CONTRIBUTING.md reminding contributors to delete their remote branch when closing a PR without merging.

## Problem

PR #121 was closed without merging, leaving the `fix/cloud-url` branch on the remote. GitHub's `delete_branch_on_merge` setting only handles merged PRs -- closed-without-merge is a gap that requires manual cleanup.

## Changes

- Added "Branch Cleanup" section to the Submitting Changes workflow in CONTRIBUTING.md
- Includes the `git push origin --delete` command for contributors
- Notes that merged PRs are handled automatically
- Deleted the stale `fix/cloud-url` remote branch (from PR #121)

## Why not automate this?

We considered a GitHub Actions workflow but decided against it:
- This repo has had one stale branch in its entire history
- A workflow for a once-a-year event violates KISS/YAGNI
- Documenting the convention has better educational value for an educational project