### PR TITLE
fix: use regex word boundaries for variable substitution in plot_function

### DIFF
--- a/src/math_mcp/server.py
+++ b/src/math_mcp/server.py
@@ -8,6 +8,7 @@ Uses FastMCP 2.0 patterns with structured output and multi-transport support.
 import asyncio
 import logging
 import math
+import re
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -91,7 +92,7 @@ ALLOWED_TRENDS = {"bullish", "bearish", "volatile"}
 # === CONSTANTS ===
 
 MATH_FUNCTIONS_SINGLE = ["sin", "cos", "tan", "log", "sqrt", "abs"]
-MATH_FUNCTIONS_ALL = {"sin", "cos", "tan", "log", "sqrt", "abs", "pow"}
+MATH_FUNCTIONS_ALL = {"sin", "cos", "tan", "log", "sqrt", "abs", "pow", "exp"}
 DANGEROUS_PATTERNS = ["import", "exec", "__", "eval", "open", "file"]
 
 TOPIC_KEYWORDS = {
@@ -799,9 +800,11 @@ async def plot_function(
 
         # Evaluate expression for each x value
         y_values = []
+        var_pattern = re.compile(r"\bx\b")
         for x in x_values:
-            # Replace x in expression with actual value
-            expr_with_value = expression.replace("x", f"({x})")
+            # Replace x in expression with actual value using word boundaries
+            # to avoid corrupting function names like exp, max, hex
+            expr_with_value = var_pattern.sub(f"({x})", expression)
             try:
                 y = await evaluate_with_timeout(expr_with_value)
                 y_values.append(y)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -672,5 +672,30 @@ async def test_plot_financial_line_invalid_trend(mock_context):
         await plot_financial_line.fn(30, "invalid_trend", 100.0, None, mock_context)
 
 
+def test_regex_substitution_preserves_function_names_with_x():
+    """Verify exp(x) substitution returns math.exp(1.0) not NaN/error."""
+    import math
+    import re
+
+    from math_mcp.server import safe_eval_expression
+
+    expression = "exp(x)"
+    substituted = re.sub(r"\bx\b", "(1.0)", expression)
+    result = safe_eval_expression(substituted)
+    assert result == pytest.approx(math.exp(1.0))
+
+
+def test_regex_substitution_replaces_standalone_x_preserves_functions():
+    """Verify x*abs(x) with x=-2.0 returns -4.0 not NaN/error."""
+    import re
+
+    from math_mcp.server import safe_eval_expression
+
+    expression = "x*abs(x)"
+    substituted = re.sub(r"\bx\b", "(-2.0)", expression)
+    result = safe_eval_expression(substituted)
+    assert result == pytest.approx(-4.0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #136. The `plot_function` tool used naive `expression.replace("x", ...)` which corrupted function names containing the letter `x` (e.g., `exp`, `max`, `hex`).

## Changes

### Bug fix (`src/math_mcp/server.py`)
- Added `import re` for regex support
- Added `exp` to `MATH_FUNCTIONS_ALL` (standard math function, required for `exp(x)` expressions)
- Pre-compiled word-boundary regex pattern (`re.compile(r"\bx\b")`) outside the evaluation loop
- Replaced `expression.replace("x", f"({x})")` with `var_pattern.sub(f"({x})", expression)`

### Regression tests (`tests/test_visualization.py`)
- `test_regex_substitution_preserves_function_names_with_x`: verifies `exp(x)` with x=1.0 returns `math.exp(1.0)`, proving function names containing `x` are preserved
- `test_regex_substitution_replaces_standalone_x_preserves_functions`: verifies `x*abs(x)` with x=-2.0 returns -4.0, proving standalone `x` is substituted correctly

Both tests call `safe_eval_expression` directly after regex substitution with `pytest.approx()` numeric assertions, avoiding false positives from image-only checks.

## Testing
- All 128 tests pass
- Linting clean (ruff)
- Formatting clean (ruff format)
- Security scan: 0 findings