### PR TITLE
refactor: extract matplotlib chart generation to visualization helpers

### DIFF
--- a/src/math_mcp/server.py
+++ b/src/math_mcp/server.py
@@ -812,13 +812,6 @@ async def plot_function(
         plot_function("sin(x)", (-3.14, 3.14))
     """
 
-    # Matplotlib is guaranteed to be available (decorator handles ImportError)
-    import matplotlib
-
-    matplotlib.use("Agg")  # Non-interactive backend
-    import matplotlib.pyplot as plt
-    import numpy as np
-
     # FastMCP 2.0 Context logging
     if ctx:
         await ctx.info(f"Plotting function: {expression} over range {x_range}")
@@ -831,7 +824,9 @@ async def plot_function(
         if num_points < 2:
             raise ValueError("num_points must be at least 2")
 
-        # Generate x values
+        # Generate x values and evaluate expression
+        import numpy as np
+
         x_values = np.linspace(x_min, x_max, num_points)
 
         # Evaluate expression for each x value
@@ -848,25 +843,10 @@ async def plot_function(
                 # Handle domain errors (like sqrt of negative) or timeout
                 y_values.append(float("nan"))
 
-        # Create figure and plot
-        fig, ax = plt.subplots(figsize=(10, 6))
-        ax.plot(x_values, y_values, linewidth=2, color="#2E86AB")
-        ax.set_xlabel("x", fontsize=12)
-        ax.set_ylabel("f(x)", fontsize=12)
-        ax.set_title(f"Plot of f(x) = {expression}", fontsize=14, fontweight="bold")
-        ax.grid(True, alpha=0.3)
-        ax.axhline(y=0, color="k", linewidth=0.5)
-        ax.axvline(x=0, color="k", linewidth=0.5)
-
-        # Save to base64
-        import base64
-        from io import BytesIO
-
-        buffer = BytesIO()
-        plt.savefig(buffer, format="png", dpi=100, bbox_inches="tight")
-        plt.close(fig)
-        buffer.seek(0)
-        image_base64 = base64.b64encode(buffer.read()).decode("utf-8")
+        # Delegate rendering to visualization helper
+        image_base64 = visualization.create_function_plot(
+            x_values.tolist(), y_values, expression
+        ).decode("utf-8")
 
         # Classify difficulty
         difficulty = _classify_expression_difficulty(expression)
@@ -947,13 +927,6 @@ async def create_histogram(
     if bins < 1:
         raise ValueError("bins must be at least 1")
 
-    # Matplotlib is guaranteed to be available (decorator handles ImportError)
-    import matplotlib
-
-    matplotlib.use("Agg")  # Non-interactive backend
-    import matplotlib.pyplot as plt
-    import numpy  # noqa: F401 - imported for side effects, required by matplotlib
-
     # FastMCP 2.0 Context logging
     if ctx:
         await ctx.info(f"Creating histogram with {len(data)} data points and {bins} bins")
@@ -974,39 +947,10 @@ async def create_histogram(
         median_val = stats.median(data)
         std_dev = stats.stdev(data) if len(data) > 1 else 0
 
-        # Create histogram
-        fig, ax = plt.subplots(figsize=(10, 6))
-        n, bins_edges, patches = ax.hist(
-            data, bins=bins, color="#A23B72", alpha=0.7, edgecolor="black"
-        )
-
-        # Add vertical lines for mean and median
-        ax.axvline(
-            mean_val, color="#F18F01", linestyle="--", linewidth=2, label=f"Mean: {mean_val:.2f}"
-        )
-        ax.axvline(
-            median_val,
-            color="#C73E1D",
-            linestyle="-.",
-            linewidth=2,
-            label=f"Median: {median_val:.2f}",
-        )
-
-        ax.set_xlabel("Value", fontsize=12)
-        ax.set_ylabel("Frequency", fontsize=12)
-        ax.set_title(title, fontsize=14, fontweight="bold")
-        ax.legend()
-        ax.grid(True, alpha=0.3, axis="y")
-
-        # Save to base64
-        import base64
-        from io import BytesIO
-
-        buffer = BytesIO()
-        plt.savefig(buffer, format="png", dpi=100, bbox_inches="tight")
-        plt.close(fig)
-        buffer.seek(0)
-        image_base64 = base64.b64encode(buffer.read()).decode("utf-8")
+        # Delegate rendering to visualization helper
+        image_base64 = visualization.create_histogram_chart(
+            data, bins, title, mean_val, median_val, std_dev
+        ).decode("utf-8")
 
         return {
             "content": [

--- a/src/math_mcp/visualization.py
+++ b/src/math_mcp/visualization.py
@@ -86,6 +86,96 @@ def _validate_color_scheme(color: str | None) -> str:
     return "#2E86AB"
 
 
+def create_function_plot(
+    x_values: list[float],
+    y_values: list[float],
+    expression: str,
+) -> bytes:
+    """Create a function plot from pre-computed x/y values.
+
+    Args:
+        x_values: X-axis values (pre-computed by caller)
+        y_values: Y-axis values (pre-computed by caller, may contain NaN)
+        expression: Expression string for chart title
+
+    Returns:
+        Base64-encoded PNG image bytes
+
+    Raises:
+        ValueError: If x_values and y_values have different lengths
+    """
+    if len(x_values) != len(y_values):
+        raise ValueError("x_values and y_values must have the same length")
+
+    _, plt, _ = _setup_matplotlib()
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(x_values, y_values, linewidth=2, color="#2E86AB")
+    ax.set_xlabel("x", fontsize=12)
+    ax.set_ylabel("f(x)", fontsize=12)
+    ax.set_title(f"Plot of f(x) = {expression}", fontsize=14, fontweight="bold")
+    ax.grid(True, alpha=0.3)
+    ax.axhline(y=0, color="k", linewidth=0.5)
+    ax.axvline(x=0, color="k", linewidth=0.5)
+
+    return _encode_figure_to_base64(fig).encode("utf-8")
+
+
+def create_histogram_chart(
+    data: list[float],
+    bins: int,
+    title: str,
+    mean_val: float,
+    median_val: float,
+    std_dev: float,
+) -> bytes:
+    """Create a histogram from data with mean and median lines.
+
+    Args:
+        data: Data points for histogram
+        bins: Number of bins
+        title: Chart title
+        mean_val: Pre-computed mean value
+        median_val: Pre-computed median value
+        std_dev: Pre-computed standard deviation
+
+    Returns:
+        Base64-encoded PNG image bytes
+
+    Raises:
+        ValueError: If data is empty or bins < 1
+    """
+    if not data:
+        raise ValueError("Cannot create histogram with empty data")
+    if bins < 1:
+        raise ValueError("bins must be at least 1")
+
+    _, plt, _ = _setup_matplotlib()
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.hist(data, bins=bins, color="#A23B72", alpha=0.7, edgecolor="black")
+
+    # Add vertical lines for mean and median
+    ax.axvline(
+        mean_val, color="#F18F01", linestyle="--", linewidth=2, label=f"Mean: {mean_val:.2f}"
+    )
+    ax.axvline(
+        median_val,
+        color="#C73E1D",
+        linestyle="-.",
+        linewidth=2,
+        label=f"Median: {median_val:.2f}",
+    )
+
+    ax.set_xlabel("Value", fontsize=12)
+    ax.set_ylabel("Frequency", fontsize=12)
+    ax.set_title(title, fontsize=14, fontweight="bold")
+    ax.legend()
+    ax.grid(True, alpha=0.3, axis="y")
+
+    return _encode_figure_to_base64(fig).encode("utf-8")
+
+
 # === CHART GENERATORS ===
 
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -772,5 +772,101 @@ async def test_requires_matplotlib_import_error(mock_context):
     assert annotations["topic"] == "visualization"
 
 
+def test_create_function_plot_basic():
+    """Test create_function_plot with simple x/y data (happy path).
+
+    Arrange: Create simple x and y value lists
+    Act: Call create_function_plot with valid inputs
+    Assert: Returns base64-encoded PNG bytes
+    """
+    from math_mcp.visualization import create_function_plot
+
+    # Arrange: Simple linear function data
+    x_values = [0.0, 1.0, 2.0, 3.0, 4.0]
+    y_values = [0.0, 1.0, 2.0, 3.0, 4.0]
+    expression = "x"
+
+    # Act: Call the helper function
+    result = create_function_plot(x_values, y_values, expression)
+
+    # Assert: Returns bytes (base64-encoded PNG)
+    assert isinstance(result, bytes)
+    assert result.startswith(b"iVBORw0KGgo")  # PNG magic bytes in base64
+
+
+def test_create_function_plot_with_nan():
+    """Test create_function_plot handles NaN values in y_values (edge case).
+
+    Arrange: Create x/y data with NaN values (domain errors)
+    Act: Call create_function_plot with NaN in y_values
+    Assert: Returns valid PNG despite NaN (matplotlib handles gracefully)
+    """
+    import math
+
+    from math_mcp.visualization import create_function_plot
+
+    # Arrange: Data with NaN (simulating domain error like sqrt(-1))
+    x_values = [-2.0, -1.0, 0.0, 1.0, 2.0]
+    y_values = [float("nan"), float("nan"), 0.0, 1.0, 2.0]
+    expression = "sqrt(x)"
+
+    # Act: Call the helper function
+    result = create_function_plot(x_values, y_values, expression)
+
+    # Assert: Returns valid PNG despite NaN values
+    assert isinstance(result, bytes)
+    assert result.startswith(b"iVBORw0KGgo")
+
+
+def test_create_histogram_chart_basic():
+    """Test create_histogram_chart with sample data (happy path).
+
+    Arrange: Create sample data and pre-computed statistics
+    Act: Call create_histogram_chart with valid inputs
+    Assert: Returns base64-encoded PNG bytes
+    """
+    from math_mcp.visualization import create_histogram_chart
+
+    # Arrange: Sample data with pre-computed statistics
+    data = [1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 5.0]
+    bins = 5
+    title = "Test Distribution"
+    mean_val = 3.0
+    median_val = 3.0
+    std_dev = 1.2
+
+    # Act: Call the helper function
+    result = create_histogram_chart(data, bins, title, mean_val, median_val, std_dev)
+
+    # Assert: Returns bytes (base64-encoded PNG)
+    assert isinstance(result, bytes)
+    assert result.startswith(b"iVBORw0KGgo")  # PNG magic bytes in base64
+
+
+def test_create_histogram_chart_bins_exceeds_data():
+    """Test create_histogram_chart when bins > data points (edge case).
+
+    Arrange: Create data with fewer points than bins
+    Act: Call create_histogram_chart with bins > len(data)
+    Assert: Returns valid PNG (matplotlib handles gracefully)
+    """
+    from math_mcp.visualization import create_histogram_chart
+
+    # Arrange: Only 3 data points but 10 bins requested
+    data = [1.0, 2.0, 3.0]
+    bins = 10
+    title = "Sparse Distribution"
+    mean_val = 2.0
+    median_val = 2.0
+    std_dev = 1.0
+
+    # Act: Call the helper function
+    result = create_histogram_chart(data, bins, title, mean_val, median_val, std_dev)
+
+    # Assert: Returns valid PNG despite bins > data points
+    assert isinstance(result, bytes)
+    assert result.startswith(b"iVBORw0KGgo")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Extract inline matplotlib chart generation from `plot_function` and `create_histogram` in `server.py` into dedicated helper functions in `visualization.py`, matching the delegation pattern already used by the other 4 chart tools.

## Changes

- Add `create_function_plot()` helper in `visualization.py` for function plotting
- Add `create_histogram_chart()` helper in `visualization.py` for histogram generation
- Refactor `plot_function` to delegate rendering to `create_function_plot()`
- Refactor `create_histogram` to delegate rendering to `create_histogram_chart()`
- Remove inline matplotlib/base64 imports from refactored server.py functions
- Add 4 new unit tests (happy path + edge case per helper)

## Testing

- All 134 tests pass (130 existing + 4 new)
- Linting clean (ruff format + check)
- Type checking clean (pyright)
- No security findings

Closes #138