### PR TITLE
feat: add A2A v0.3 agent card for agent-to-agent discoverability

### DIFF
--- a/src/math_mcp/agent_card.py
+++ b/src/math_mcp/agent_card.py
@@ -1,0 +1,190 @@
+"""A2A v0.3 Agent Card schema models for MCP server discovery.
+
+This module implements the Agent-to-Agent (A2A) v0.3 specification for
+agent discovery and capability advertisement. The agent card is served
+at /.well-known/agent-card.json and enables other agents to discover
+and understand this server's capabilities.
+
+Reference: https://modelcontextprotocol.io/
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AgentCapabilities(BaseModel):
+    """Agent capabilities advertisement.
+
+    Describes optional capabilities the agent supports beyond basic
+    tool invocation. All fields are optional.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    streaming: bool | None = Field(
+        default=None,
+        description="Whether the agent supports streaming responses",
+    )
+    push_notifications: bool | None = Field(
+        default=None,
+        alias="pushNotifications",
+        description="Whether the agent supports push notifications",
+    )
+    state_transition_history: bool | None = Field(
+        default=None,
+        alias="stateTransitionHistory",
+        description="Whether the agent maintains state transition history",
+    )
+    extensions: list[str] | None = Field(
+        default=None,
+        description="List of supported protocol extensions",
+    )
+
+
+class AgentSkill(BaseModel):
+    """A skill or capability the agent can perform.
+
+    Skills represent discrete, invocable capabilities. Each skill maps
+    to an MCP tool with metadata for discovery and understanding.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str = Field(
+        ...,
+        description="Unique identifier for the skill",
+    )
+    name: str = Field(
+        ...,
+        description="Human-readable skill name",
+    )
+    description: str = Field(
+        ...,
+        description="Detailed description of what the skill does",
+    )
+    tags: list[str] = Field(
+        ...,
+        description="Tags for categorization and discovery",
+    )
+    examples: list[str] | None = Field(
+        default=None,
+        description="Example use cases or invocations",
+    )
+    input_modes: list[str] | None = Field(
+        default=None,
+        alias="inputModes",
+        description="Supported input media types",
+    )
+    output_modes: list[str] | None = Field(
+        default=None,
+        alias="outputModes",
+        description="Supported output media types",
+    )
+
+
+class AgentInterface(BaseModel):
+    """Interface for communicating with the agent.
+
+    Specifies how to connect to and communicate with this agent,
+    including the protocol binding used.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    url: str = Field(
+        ...,
+        description="URL where the agent can be reached",
+    )
+    protocol_binding: str = Field(
+        ...,
+        alias="protocolBinding",
+        description="Protocol binding (e.g., 'HTTP+JSON')",
+    )
+
+
+class AgentProvider(BaseModel):
+    """Information about the agent's provider/organization.
+
+    Identifies who created and maintains this agent.
+    """
+
+    organization: str = Field(
+        ...,
+        description="Organization name",
+    )
+    url: str | None = Field(
+        default=None,
+        description="Organization website URL",
+    )
+
+
+class AgentCard(BaseModel):
+    """A2A v0.3 Agent Card for MCP server discovery.
+
+    The agent card is the primary discovery mechanism for agents.
+    It describes the agent's capabilities, skills, and how to interact
+    with it. Served at /.well-known/agent-card.json per A2A spec.
+
+    Reference: https://modelcontextprotocol.io/
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    protocol_version: str = Field(
+        default="1.0",
+        alias="protocolVersion",
+        description="A2A protocol version",
+    )
+    name: str = Field(
+        ...,
+        description="Agent name",
+    )
+    description: str = Field(
+        ...,
+        description="Agent description",
+    )
+    version: str = Field(
+        ...,
+        description="Agent version",
+    )
+    capabilities: AgentCapabilities = Field(
+        ...,
+        description="Agent capabilities",
+    )
+    default_input_modes: list[str] = Field(
+        ...,
+        alias="defaultInputModes",
+        description="Default input media types",
+    )
+    default_output_modes: list[str] = Field(
+        ...,
+        alias="defaultOutputModes",
+        description="Default output media types",
+    )
+    skills: list[AgentSkill] = Field(
+        ...,
+        description="List of skills the agent can perform",
+    )
+    supported_interfaces: list[AgentInterface] | None = Field(
+        default=None,
+        alias="supportedInterfaces",
+        description="Interfaces for communicating with the agent",
+    )
+    provider: AgentProvider | None = Field(
+        default=None,
+        description="Agent provider information",
+    )
+    documentation_url: str | None = Field(
+        default=None,
+        alias="documentationUrl",
+        description="URL to agent documentation",
+    )
+    icon_url: str | None = Field(
+        default=None,
+        alias="iconUrl",
+        description="URL to agent icon",
+    )
+    supports_extended_agent_card: bool | None = Field(
+        default=None,
+        alias="supportsExtendedAgentCard",
+        description="Whether extended agent card is supported",
+    )

--- a/src/math_mcp/server.py
+++ b/src/math_mcp/server.py
@@ -14,6 +14,8 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from functools import wraps
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
 from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
@@ -24,9 +26,11 @@ from fastmcp.server.middleware.rate_limiting import (
     SlidingWindowRateLimitingMiddleware,
 )
 from pydantic import Field, SkipValidation
+from starlette.responses import JSONResponse
 
 # Import visualization functions (using absolute import for FastMCP Cloud compatibility)
 from math_mcp import visualization
+from math_mcp.agent_card import AgentCard, AgentSkill
 from math_mcp.eval import (
     _classify_expression_difficulty,
     _classify_expression_topic,
@@ -1390,11 +1394,102 @@ Make your explanation clear and educational, suitable for someone learning about
 """
 
 
+# === AGENT CARD ENDPOINT ===
+
+
+async def build_agent_card() -> AgentCard:
+    """Build A2A v0.3 agent card with dynamic tool introspection.
+
+    Introspects the MCP server's tools and builds a complete agent card
+    that describes this server's capabilities, skills, and interfaces.
+    This enables agent discovery and capability advertisement per A2A spec.
+
+    Returns:
+        AgentCard: Complete A2A v0.3 agent card with all required fields.
+    """
+    # Introspect tools from the MCP server
+    tools = (await mcp.get_tools()).values()
+
+    # Build skills from tools
+    skills: list[AgentSkill] = []
+    for tool in tools:
+        skill = AgentSkill.model_validate(
+            {
+                "id": tool.name,
+                "name": tool.name.replace("_", " ").title(),
+                "description": tool.description or f"Tool: {tool.name}",
+                "tags": ["mcp", "tool"],
+                "inputModes": ["application/json"],
+                "outputModes": ["application/json", "text/plain"],
+            }
+        )
+        skills.append(skill)
+
+    # Get dynamic version from package metadata
+    try:
+        version = pkg_version("math-mcp-learning-server")
+    except PackageNotFoundError:
+        # Fallback if package metadata is unavailable
+        version = "0.10.3"
+
+    # Build agent card with server metadata
+    agent_card = AgentCard.model_validate(
+        {
+            "protocolVersion": "1.0",
+            "name": "Math Learning Server",
+            "description": "Educational MCP server demonstrating FastMCP 2.0 best practices for math operations, visualization, and persistent workspaces.",
+            "version": version,
+            "capabilities": {
+                "streaming": False,
+                "pushNotifications": False,
+                "stateTransitionHistory": False,
+            },
+            "defaultInputModes": ["application/json"],
+            "defaultOutputModes": ["application/json", "text/plain", "image/png"],
+            "skills": [s.model_dump(by_alias=True) for s in skills],
+            "documentationUrl": "https://github.com/clouatre-labs/math-mcp-learning-server",
+            "supportsExtendedAgentCard": False,
+        }
+    )
+
+    return agent_card
+
+
+# === A2A AGENT CARD ENDPOINT ===
+
+
+@mcp.custom_route("/.well-known/agent-card.json", methods=["GET"])
+async def agent_card_endpoint(request) -> JSONResponse:
+    """Serve A2A v0.3 agent card for server discovery.
+
+    This endpoint implements the A2A (Agent-to-Agent) v0.3 specification
+    for agent discovery. It provides metadata about the MCP server's
+    capabilities, skills, and interfaces in a standardized format.
+
+    The response uses camelCase JSON serialization as required by the
+    A2A specification, with Pydantic model_dump_json(by_alias=True).
+
+    Args:
+        request: Starlette Request object (unused but required by route handler).
+
+    Returns:
+        JSONResponse: A2A v0.3 agent card with server metadata and skills.
+    """
+    card = await build_agent_card()
+    # Use model_dump with by_alias=True for camelCase JSON serialization
+    return JSONResponse(card.model_dump(by_alias=True, mode="json"))
+
+
 # === MAIN ENTRY POINT ===
 
 
 def main() -> None:
-    """Main entry point supporting multiple transports."""
+    """Main entry point supporting multiple transports.
+
+    Supports stdio, sse, and streamable-http transports. The A2A agent
+    card endpoint is automatically registered via @mcp.custom_route()
+    and available on all HTTP-based transports.
+    """
     import sys
     from typing import Literal, cast
 
@@ -1404,7 +1499,7 @@ def main() -> None:
         if sys.argv[1] in ["stdio", "sse", "streamable-http"]:
             transport = cast(Literal["stdio", "sse", "streamable-http"], sys.argv[1])
 
-    # Run with specified transport
+    # Run the MCP server with the specified transport
     mcp.run(transport=transport)
 
 

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -1,0 +1,149 @@
+"""A2A v0.3 agent card endpoint tests.
+
+Tests verify the agent card is correctly generated, served at the
+well-known endpoint, and conforms to A2A v0.3 schema.
+"""
+
+from importlib.metadata import version as pkg_version
+
+import httpx
+import pytest
+
+
+async def test_agent_card_endpoint_and_json_valid(http_server: str) -> None:
+    """Test agent card endpoint is accessible and returns valid JSON."""
+    async with httpx.AsyncClient() as client:
+        agent_card_url = http_server.replace("/mcp", "") + "/.well-known/agent-card.json"
+        response = await client.get(agent_card_url)
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/json"
+
+        # Verify JSON is valid by parsing
+        card = response.json()
+        assert isinstance(card, dict)
+
+
+async def test_agent_card_has_required_fields(http_server: str) -> None:
+    """Test agent card contains all required A2A v0.3 fields."""
+    async with httpx.AsyncClient() as client:
+        agent_card_url = http_server.replace("/mcp", "") + "/.well-known/agent-card.json"
+        response = await client.get(agent_card_url)
+
+        card = response.json()
+
+        # Required fields per A2A v0.3 spec
+        assert "protocolVersion" in card
+        assert card["protocolVersion"] == "1.0"
+        assert "name" in card
+        assert card["name"] == "Math Learning Server"
+        assert "description" in card
+        assert len(card["description"]) > 0
+        assert "version" in card
+        assert "capabilities" in card
+        assert "defaultInputModes" in card
+        assert "defaultOutputModes" in card
+        assert "skills" in card
+        assert "documentationUrl" in card
+
+
+async def test_agent_card_version_matches_package(http_server: str) -> None:
+    """Test agent card version matches package metadata."""
+    async with httpx.AsyncClient() as client:
+        agent_card_url = http_server.replace("/mcp", "") + "/.well-known/agent-card.json"
+        response = await client.get(agent_card_url)
+
+        card = response.json()
+
+        # Get version from package metadata
+        expected_version = pkg_version("math-mcp-learning-server")
+        assert card["version"] == expected_version
+
+
+async def test_agent_card_camel_case_serialization(http_server: str) -> None:
+    """Test agent card uses camelCase JSON serialization per A2A spec."""
+    async with httpx.AsyncClient() as client:
+        agent_card_url = http_server.replace("/mcp", "") + "/.well-known/agent-card.json"
+        response = await client.get(agent_card_url)
+
+        card = response.json()
+
+        # A2A spec requires camelCase in JSON
+        assert "protocolVersion" in card
+        assert "defaultInputModes" in card
+        assert "defaultOutputModes" in card
+        assert "documentationUrl" in card
+
+        # Should NOT have snake_case versions
+        assert "protocol_version" not in card
+        assert "default_input_modes" not in card
+        assert "default_output_modes" not in card
+
+
+async def test_agent_card_capabilities_and_modes(http_server: str) -> None:
+    """Test agent card capabilities structure and input/output modes."""
+    async with httpx.AsyncClient() as client:
+        agent_card_url = http_server.replace("/mcp", "") + "/.well-known/agent-card.json"
+        response = await client.get(agent_card_url)
+
+        card = response.json()
+
+        # Verify capabilities structure
+        capabilities = card["capabilities"]
+        assert isinstance(capabilities, dict)
+        assert "streaming" in capabilities
+        assert "pushNotifications" in capabilities
+        assert "stateTransitionHistory" in capabilities
+
+        # Verify input/output modes
+        assert isinstance(card["defaultInputModes"], list)
+        assert len(card["defaultInputModes"]) > 0
+        assert isinstance(card["defaultOutputModes"], list)
+        assert len(card["defaultOutputModes"]) > 0
+
+
+async def test_agent_card_skills_structure(http_server: str) -> None:
+    """Test agent card skills have correct structure and include registered tools."""
+    async with httpx.AsyncClient() as client:
+        agent_card_url = http_server.replace("/mcp", "") + "/.well-known/agent-card.json"
+        response = await client.get(agent_card_url)
+
+        card = response.json()
+        skills = card["skills"]
+
+        # Skills should not be empty
+        assert isinstance(skills, list)
+        assert len(skills) > 0
+
+        # Verify skill structure
+        for skill in skills:
+            assert "id" in skill
+            assert "name" in skill
+            assert "description" in skill
+            assert "tags" in skill
+            assert isinstance(skill["tags"], list)
+            assert "mcp" in skill["tags"]
+            assert "tool" in skill["tags"]
+            assert "inputModes" in skill
+            assert "outputModes" in skill
+
+        # Verify key tools are present
+        skill_ids = [skill["id"] for skill in skills]
+        assert "calculate" in skill_ids
+        assert "statistics" in skill_ids
+
+
+async def test_agent_card_consistency_across_requests(http_server: str) -> None:
+    """Test agent card is consistent across multiple requests."""
+    async with httpx.AsyncClient() as client:
+        agent_card_url = http_server.replace("/mcp", "") + "/.well-known/agent-card.json"
+
+        # Make two requests
+        response1 = await client.get(agent_card_url)
+        response2 = await client.get(agent_card_url)
+
+        card1 = response1.json()
+        card2 = response2.json()
+
+        # Should be identical
+        assert card1 == card2


### PR DESCRIPTION
## Summary

Adds a `/.well-known/agent-card.json` endpoint following the A2A (Agent-to-Agent) v0.3 specification, enabling other agents to discover and understand this server's capabilities.

Closes #163
Closes #166

## Changes

- **`src/math_mcp/agent_card.py`** (new): Pydantic models for A2A v0.3 schema (AgentCard, AgentSkill, AgentCapabilities, AgentInterface, AgentProvider) with camelCase serialization via field aliases
- **`src/math_mcp/server.py`**: `build_agent_card()` function with runtime tool introspection via public `mcp.get_tools()` API, and `@mcp.custom_route()` endpoint registration
- **`tests/test_agent_card.py`** (new): 7 focused HTTP integration tests covering endpoint availability, required fields, dynamic version, camelCase serialization, capabilities, skills structure, and response consistency

## Design Decisions

- **Runtime tool introspection**: Skills are generated dynamically from registered MCP tools (all 17), not hardcoded. Adding a new tool automatically updates the agent card.
- **`@mcp.custom_route()`**: Uses FastMCP's built-in custom route API instead of manual Starlette route wiring. Cleaner, less code, automatically available on all HTTP transports.
- **Dynamic version**: Uses `importlib.metadata.version()` to read version from package metadata, staying in sync with `pyproject.toml`. Catches `PackageNotFoundError` specifically rather than broad `Exception`.
- **No `supportedInterfaces`**: Omitted (optional per A2A spec) since the client already knows the server URL from hitting the agent card endpoint.
- **No new dependencies**: Uses only FastMCP, Pydantic, and Starlette (all existing).

## Testing

```
141 passed (7 new agent card tests + 134 existing)
Ruff check: clean
Ruff format: clean
Pyright: clean (new code)
```