### PR TITLE
refactor: add typing.Final annotations and __all__ export list

### DIFF
--- a/src/math_mcp/settings.py
+++ b/src/math_mcp/settings.py
@@ -1,7 +1,30 @@
 """Configuration management for Math MCP Server."""
 
+from typing import Final
+
 from pydantic import ConfigDict, Field, field_validator, validate_call
 from pydantic_settings import BaseSettings
+
+__all__ = [
+    "MathMCPSettings",
+    "validated_tool",
+    "MATH_FUNCTIONS_SINGLE",
+    "MATH_FUNCTIONS_ALL",
+    "DANGEROUS_PATTERNS",
+    "ALLOWED_OPERATIONS",
+    "ALLOWED_TRENDS",
+    "TOPIC_KEYWORDS",
+    "TEMP_CONVERSIONS",
+    "EXPRESSION_TIMEOUT_SECONDS",
+    "RATE_LIMIT_PER_MINUTE",
+    "MAX_EXPRESSION_LENGTH",
+    "MAX_STRING_PARAM_LENGTH",
+    "MAX_ARRAY_SIZE",
+    "MAX_GROUPS_COUNT",
+    "MAX_GROUP_SIZE",
+    "MAX_VARIABLE_NAME_LENGTH",
+    "MAX_DAYS_FINANCIAL",
+]
 
 
 class MathMCPSettings(BaseSettings):
@@ -64,12 +87,12 @@ _settings = MathMCPSettings()
 
 # === DERIVED CONSTANTS (from shared _settings instance) ===
 
-EXPRESSION_TIMEOUT_SECONDS: float = _settings.math_timeout
-RATE_LIMIT_PER_MINUTE: int = _settings.mcp_rate_limit_per_minute
-MAX_EXPRESSION_LENGTH: int = _settings.max_expression_length
-MAX_STRING_PARAM_LENGTH: int = _settings.max_string_param_length
-MAX_ARRAY_SIZE: int = _settings.max_array_size
-MAX_GROUPS_COUNT: int = _settings.max_groups_count
-MAX_GROUP_SIZE: int = _settings.max_group_size
-MAX_VARIABLE_NAME_LENGTH: int = _settings.max_variable_name_length
-MAX_DAYS_FINANCIAL: int = _settings.max_days_financial
+EXPRESSION_TIMEOUT_SECONDS: Final[float] = _settings.math_timeout
+RATE_LIMIT_PER_MINUTE: Final[int] = _settings.mcp_rate_limit_per_minute
+MAX_EXPRESSION_LENGTH: Final[int] = _settings.max_expression_length
+MAX_STRING_PARAM_LENGTH: Final[int] = _settings.max_string_param_length
+MAX_ARRAY_SIZE: Final[int] = _settings.max_array_size
+MAX_GROUPS_COUNT: Final[int] = _settings.max_groups_count
+MAX_GROUP_SIZE: Final[int] = _settings.max_group_size
+MAX_VARIABLE_NAME_LENGTH: Final[int] = _settings.max_variable_name_length
+MAX_DAYS_FINANCIAL: Final[int] = _settings.max_days_financial

--- a/tests/test_math_operations.py
+++ b/tests/test_math_operations.py
@@ -356,7 +356,7 @@ async def test_evaluate_with_timeout_custom_timeout(monkeypatch):
     """Test timeout configuration via environment variable."""
     import math_mcp.eval
 
-    monkeypatch.setattr(math_mcp.eval, "EXPRESSION_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(math_mcp.eval, "EXPRESSION_TIMEOUT_SECONDS", 0.1)  # type: ignore[misc]
 
     def slow_eval(expr):
         import time
@@ -377,7 +377,7 @@ async def test_rate_limit_env_var_configuration(monkeypatch):
     """Test rate limit configuration via environment variable."""
     import math_mcp.server
 
-    monkeypatch.setattr(math_mcp.server, "RATE_LIMIT_PER_MINUTE", 50)
+    monkeypatch.setattr(math_mcp.server, "RATE_LIMIT_PER_MINUTE", 50)  # type: ignore[misc]
 
     assert math_mcp.server.RATE_LIMIT_PER_MINUTE == 50
 
@@ -387,7 +387,7 @@ async def test_rate_limit_disabled_when_zero(monkeypatch):
     """Test rate limiting can be disabled by setting to 0."""
     import math_mcp.server
 
-    monkeypatch.setattr(math_mcp.server, "RATE_LIMIT_PER_MINUTE", 0)
+    monkeypatch.setattr(math_mcp.server, "RATE_LIMIT_PER_MINUTE", 0)  # type: ignore[misc]
 
     assert math_mcp.server.RATE_LIMIT_PER_MINUTE == 0
 
@@ -426,7 +426,7 @@ async def test_rate_limit_default_value(monkeypatch):
     """Test default rate limit is 100 requests per minute."""
     import math_mcp.server
 
-    monkeypatch.setattr(math_mcp.server, "RATE_LIMIT_PER_MINUTE", 100)
+    monkeypatch.setattr(math_mcp.server, "RATE_LIMIT_PER_MINUTE", 100)  # type: ignore[misc]
 
     assert math_mcp.server.RATE_LIMIT_PER_MINUTE == 100
 
@@ -731,7 +731,7 @@ async def test_env_var_configuration(monkeypatch):
     """Test that size limits can be configured via environment variables."""
     import math_mcp.server
 
-    monkeypatch.setattr(math_mcp.server, "MAX_EXPRESSION_LENGTH", 100)
+    monkeypatch.setattr(math_mcp.server, "MAX_EXPRESSION_LENGTH", 100)  # type: ignore[misc]
 
     assert math_mcp.server.MAX_EXPRESSION_LENGTH == 100
 


### PR DESCRIPTION
## Summary

Adds `typing.Final` annotations to all 9 derived constants in `settings.py` and declares the module's public API surface via `__all__`. Also adds `# type: ignore[misc]` to 5 monkeypatch lines in tests that reassign Final-annotated constants.

Closes #170

## Changes

### `src/math_mcp/settings.py`
- Added `from typing import Final` import
- Added `__all__` with 18 public exports (MathMCPSettings, validated_tool, 7 base constants, 9 derived constants)
- Annotated 9 derived constants with `Final[type]`: EXPRESSION_TIMEOUT_SECONDS, RATE_LIMIT_PER_MINUTE, MAX_EXPRESSION_LENGTH, MAX_STRING_PARAM_LENGTH, MAX_ARRAY_SIZE, MAX_GROUPS_COUNT, MAX_GROUP_SIZE, MAX_VARIABLE_NAME_LENGTH, MAX_DAYS_FINANCIAL

### `tests/test_math_operations.py`
- Added `# type: ignore[misc]` to 5 monkeypatch.setattr lines (lines 359, 380, 390, 429, 734) that reassign Final constants during testing

## Testing

- All 141 tests pass
- Ruff lint/format: clean
- Pyright: clean (no new errors)
- Gitleaks: no leaks
- Zero runtime impact (compile-time only changes)