### PR TITLE
refactor: add message parameter to progress reporting calls

### DIFF
--- a/src/math_mcp/tools/matrix.py
+++ b/src/math_mcp/tools/matrix.py
@@ -411,11 +411,11 @@ async def matrix_inverse(
     try:
         # Report initial progress
         if ctx:
-            await ctx.report_progress(0, 3)
+            await ctx.report_progress(0, 3, "Validating matrix")
 
         # Stage 1: Validate matrix
         if ctx:
-            await ctx.report_progress(1, 3)
+            await ctx.report_progress(1, 3, "Checking singularity")
 
         mat = _validate_matrix(matrix)
 
@@ -427,7 +427,7 @@ async def matrix_inverse(
 
         # Stage 2: Check singularity
         if ctx:
-            await ctx.report_progress(2, 3)
+            await ctx.report_progress(2, 3, "Computing inverse")
 
         det = la.det(mat)  # type: ignore
         if abs(det) < 1e-10:
@@ -438,7 +438,7 @@ async def matrix_inverse(
 
         # Stage 3: Compute inverse and complete
         if ctx:
-            await ctx.report_progress(3, 3)
+            await ctx.report_progress(3, 3, "Complete")
 
         result = la.inv(mat)  # type: ignore
 
@@ -520,11 +520,11 @@ async def matrix_eigenvalues(
     try:
         # Report initial progress
         if ctx:
-            await ctx.report_progress(0, 2)
+            await ctx.report_progress(0, 2, "Validating matrix")
 
         # Stage 1: Validate matrix
         if ctx:
-            await ctx.report_progress(1, 2)
+            await ctx.report_progress(1, 2, "Calculating eigenvalues")
 
         mat = _validate_matrix(matrix)
 
@@ -536,7 +536,7 @@ async def matrix_eigenvalues(
 
         # Stage 2: Calculate eigenvalues and complete
         if ctx:
-            await ctx.report_progress(2, 2)
+            await ctx.report_progress(2, 2, "Complete")
 
         eigenvalues = la.eigvals(mat)  # type: ignore
 

--- a/src/math_mcp/tools/visualization.py
+++ b/src/math_mcp/tools/visualization.py
@@ -145,7 +145,7 @@ async def plot_function(
         for i, x in enumerate(x_values):
             # Report progress at ~10% intervals
             if ctx and i % max(1, num_points // 10) == 0:
-                await ctx.report_progress(i, num_points)
+                await ctx.report_progress(i, num_points, f"Evaluating points: {i}/{num_points}")
 
             # Replace x in expression with actual value using word boundaries
             # to avoid corrupting function names like exp, max, hex
@@ -159,7 +159,7 @@ async def plot_function(
 
         # Report final progress
         if ctx:
-            await ctx.report_progress(num_points, num_points)
+            await ctx.report_progress(num_points, num_points, "Rendering plot")
 
         # Delegate rendering to visualization helper
         image_base64 = visualization.create_function_plot(
@@ -264,11 +264,11 @@ async def create_histogram(
 
         # Report initial progress
         if ctx:
-            await ctx.report_progress(0, 3)
+            await ctx.report_progress(0, 3, "Validating inputs")
 
         # Stage 1: Calculate statistics
         if ctx:
-            await ctx.report_progress(1, 3)
+            await ctx.report_progress(1, 3, "Calculating statistics")
 
         import statistics as stats
 
@@ -278,7 +278,7 @@ async def create_histogram(
 
         # Stage 2: Render visualization
         if ctx:
-            await ctx.report_progress(2, 3)
+            await ctx.report_progress(2, 3, "Rendering histogram")
 
         image_base64 = visualization.create_histogram_chart(
             data, bins, title, mean_val, median_val, std_dev
@@ -286,7 +286,7 @@ async def create_histogram(
 
         # Stage 3: Complete
         if ctx:
-            await ctx.report_progress(3, 3)
+            await ctx.report_progress(3, 3, "Complete")
 
         return {
             "content": [
@@ -380,15 +380,15 @@ async def plot_line_chart(
     try:
         # Stage 0: Start
         if ctx:
-            await ctx.report_progress(0, 2)
+            await ctx.report_progress(0, 2, "Validating data")
 
         # Stage 1: Validate data
         if ctx:
-            await ctx.report_progress(1, 2)
+            await ctx.report_progress(1, 2, "Creating chart")
 
         # Stage 2: Render and complete
         if ctx:
-            await ctx.report_progress(2, 2)
+            await ctx.report_progress(2, 2, "Complete")
 
         image_base64 = visualization.create_line_chart(
             x_data=x_data,
@@ -493,15 +493,15 @@ async def plot_scatter_chart(
     try:
         # Stage 0: Start
         if ctx:
-            await ctx.report_progress(0, 2)
+            await ctx.report_progress(0, 2, "Validating data")
 
         # Stage 1: Validate data
         if ctx:
-            await ctx.report_progress(1, 2)
+            await ctx.report_progress(1, 2, "Creating chart")
 
         # Stage 2: Render and complete
         if ctx:
-            await ctx.report_progress(2, 2)
+            await ctx.report_progress(2, 2, "Complete")
 
         image_base64 = visualization.create_scatter_plot(
             x_data=x_data,
@@ -601,15 +601,15 @@ async def plot_box_plot(
     try:
         # Stage 0: Start
         if ctx:
-            await ctx.report_progress(0, 2)
+            await ctx.report_progress(0, 2, "Validating data")
 
         # Stage 1: Validate data
         if ctx:
-            await ctx.report_progress(1, 2)
+            await ctx.report_progress(1, 2, "Creating chart")
 
         # Stage 2: Render and complete
         if ctx:
-            await ctx.report_progress(2, 2)
+            await ctx.report_progress(2, 2, "Complete")
 
         image_base64 = visualization.create_box_plot(
             data_groups=data_groups,
@@ -712,11 +712,11 @@ async def plot_financial_line(
     try:
         # Stage 0: Start
         if ctx:
-            await ctx.report_progress(0, 3)
+            await ctx.report_progress(0, 3, "Validating parameters")
 
         # Stage 1: Validate and generate data
         if ctx:
-            await ctx.report_progress(1, 3)
+            await ctx.report_progress(1, 3, "Generating synthetic data")
 
         # Validate trend parameter
         if trend not in ["bullish", "bearish", "volatile"]:
@@ -731,7 +731,7 @@ async def plot_financial_line(
 
         # Stage 2: Create financial chart
         if ctx:
-            await ctx.report_progress(2, 3)
+            await ctx.report_progress(2, 3, "Creating financial chart")
 
         # Create financial chart
         image_base64 = visualization.create_financial_line_chart(
@@ -744,7 +744,7 @@ async def plot_financial_line(
 
         # Stage 3: Complete
         if ctx:
-            await ctx.report_progress(3, 3)
+            await ctx.report_progress(3, 3, "Complete")
 
         # Calculate statistics
         import statistics as stats

--- a/tests/test_matrix_operations.py
+++ b/tests/test_matrix_operations.py
@@ -517,20 +517,20 @@ def mock_context():
             """Mock info logging."""
             self.info_logs.append(message)
 
-        async def report_progress(self, current: int, total: int):
+        async def report_progress(self, current: int, total: int, message: str = ""):
             """Mock progress reporting."""
-            self.progress_reports.append((current, total))
+            self.progress_reports.append((current, total, message))
 
     return MockContext()
 
 
 @pytest.mark.asyncio
 async def test_matrix_inverse_progress_reporting(mock_context):
-    """Test matrix_inverse reports progress through 3 stages.
+    """Test matrix_inverse reports progress through 4 stages with messages.
 
     Arrange: Create mock context and call matrix_inverse
     Act: Call matrix_inverse with mock context and a valid invertible matrix
-    Assert: progress_reports matches expected 3 stages: [(0, 3), (1, 3), (2, 3), (3, 3)]
+    Assert: progress_reports contains 4 stages with 3-tuples (current, total, message)
     """
     from math_mcp.tools.matrix import matrix_inverse
 
@@ -540,18 +540,24 @@ async def test_matrix_inverse_progress_reporting(mock_context):
     # Act: Call matrix_inverse with mock context
     await matrix_inverse.fn(matrix, mock_context)
 
-    # Assert: Progress reports match expected 3 stages (0, 1, 2, 3 out of 3)
-    expected_progress = [(0, 3), (1, 3), (2, 3), (3, 3)]
-    assert mock_context.progress_reports == expected_progress
+    # Assert: Progress reports contain 4 stages with 3-tuples
+    assert len(mock_context.progress_reports) == 4
+
+    # Check each stage has correct structure (current, total, message)
+    for i, (current, total, message) in enumerate(mock_context.progress_reports):
+        assert current == i
+        assert total == 3
+        assert isinstance(message, str)
+        assert len(message) > 0
 
 
 @pytest.mark.asyncio
 async def test_matrix_eigenvalues_progress_reporting(mock_context):
-    """Test matrix_eigenvalues reports progress through 2 stages.
+    """Test matrix_eigenvalues reports progress through 3 stages with messages.
 
     Arrange: Create mock context and call matrix_eigenvalues
     Act: Call matrix_eigenvalues with mock context and a valid square matrix
-    Assert: progress_reports matches expected 2 stages: [(0, 2), (1, 2), (2, 2)]
+    Assert: progress_reports contains 3 stages with 3-tuples (current, total, message)
     """
     from math_mcp.tools.matrix import matrix_eigenvalues
 
@@ -561,6 +567,12 @@ async def test_matrix_eigenvalues_progress_reporting(mock_context):
     # Act: Call matrix_eigenvalues with mock context
     await matrix_eigenvalues.fn(matrix, mock_context)
 
-    # Assert: Progress reports match expected 2 stages (0, 1, 2 out of 2)
-    expected_progress = [(0, 2), (1, 2), (2, 2)]
-    assert mock_context.progress_reports == expected_progress
+    # Assert: Progress reports contain 3 stages with 3-tuples
+    assert len(mock_context.progress_reports) == 3
+
+    # Check each stage has correct structure (current, total, message)
+    for i, (current, total, message) in enumerate(mock_context.progress_reports):
+        assert current == i
+        assert total == 2
+        assert isinstance(message, str)
+        assert len(message) > 0

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -25,9 +25,9 @@ def mock_context():
             """Mock info logging."""
             self.info_logs.append(message)
 
-        async def report_progress(self, current: int, total: int):
+        async def report_progress(self, current: int, total: int, message: str = ""):
             """Mock progress reporting."""
-            self.progress_reports.append((current, total))
+            self.progress_reports.append((current, total, message))
 
     return MockContext()
 
@@ -882,7 +882,7 @@ async def test_plot_function_progress_reporting(mock_context):
 
     Arrange: Create mock context and call plot_function
     Act: Call plot_function with mock context
-    Assert: progress_reports contains entries at ~10% intervals, starts with (0, num_points), ends with (num_points, num_points)
+    Assert: progress_reports contains 3-tuples with messages, starts with (0, num_points, message), ends with (num_points, num_points, message)
     """
     try:
         import matplotlib  # noqa: F401
@@ -900,12 +900,17 @@ async def test_plot_function_progress_reporting(mock_context):
     # Act: Call plot_function with mock context
     await plot_function.fn(expression, x_range, num_points, mock_context)
 
-    # Assert: Progress reports start with (0, num_points)
+    # Assert: Progress reports start with (0, num_points, message)
     assert len(mock_context.progress_reports) > 0
-    assert mock_context.progress_reports[0] == (0, num_points)
+    assert mock_context.progress_reports[0][0] == 0
+    assert mock_context.progress_reports[0][1] == num_points
+    assert isinstance(mock_context.progress_reports[0][2], str)
+    assert len(mock_context.progress_reports[0][2]) > 0
 
-    # Assert: Progress reports end with (num_points, num_points)
-    assert mock_context.progress_reports[-1] == (num_points, num_points)
+    # Assert: Progress reports end with (num_points, num_points, message)
+    assert mock_context.progress_reports[-1][0] == num_points
+    assert mock_context.progress_reports[-1][1] == num_points
+    assert isinstance(mock_context.progress_reports[-1][2], str)
 
     # Assert: Progress reports are at regular intervals (approximately every 10%)
     # With 100 points, we expect reports roughly every 10 points
@@ -914,11 +919,11 @@ async def test_plot_function_progress_reporting(mock_context):
 
 @pytest.mark.asyncio
 async def test_create_histogram_progress_reporting(mock_context):
-    """Test create_histogram reports progress through 4 stages.
+    """Test create_histogram reports progress through 4 stages with messages.
 
     Arrange: Create mock context and call create_histogram
     Act: Call create_histogram with mock context
-    Assert: progress_reports matches expected 4 stages: [(0, 3), (1, 3), (2, 3), (3, 3)]
+    Assert: progress_reports contains 4 stages with 3-tuples (current, total, message)
     """
     try:
         import matplotlib  # noqa: F401
@@ -936,9 +941,15 @@ async def test_create_histogram_progress_reporting(mock_context):
     # Act: Call create_histogram with mock context
     await create_histogram.fn(data, bins, title, mock_context)
 
-    # Assert: Progress reports match expected 4 stages
-    expected_progress = [(0, 3), (1, 3), (2, 3), (3, 3)]
-    assert mock_context.progress_reports == expected_progress
+    # Assert: Progress reports contain 4 stages with 3-tuples
+    assert len(mock_context.progress_reports) == 4
+
+    # Check each stage has correct structure (current, total, message)
+    for i, (current, total, message) in enumerate(mock_context.progress_reports):
+        assert current == i
+        assert total == 3
+        assert isinstance(message, str)
+        assert len(message) > 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #185. Adds descriptive `message` parameter to all 26 `report_progress()` calls across 8 tool functions, providing human-readable context to MCP clients alongside numeric progress values.

## Changes

- **`src/math_mcp/tools/visualization.py`**: Added messages to 19 `report_progress()` calls across 6 functions (`plot_function`, `create_histogram`, `plot_line_chart`, `plot_scatter_chart`, `plot_box_plot`, `plot_financial_line`)
- **`src/math_mcp/tools/matrix.py`**: Added messages to 7 `report_progress()` calls across 2 functions (`matrix_inverse`, `matrix_eigenvalues`)
- **`tests/test_visualization.py`**: Updated MockContext to capture 3-tuples `(current, total, message)`, updated assertions
- **`tests/test_matrix_operations.py`**: Updated MockContext to capture 3-tuples `(current, total, message)`, updated assertions

## Before / After

```python
# Before: client sees "33%" but no context
await ctx.report_progress(1, 3)

# After: client sees "33% - Checking matrix singularity"
await ctx.report_progress(1, 3, "Checking matrix singularity")
```

## Testing

- All 159 tests pass
- Linting clean (ruff)
- Type checking clean (pyright)
- No behavioral changes beyond added metadata