### PR TITLE
fix(ci): use .verification.verified for GPG tag check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,17 +46,17 @@ jobs:
             exit 1
           fi
           
-          # Get tag object details
+          # Get tag object details (signature lives under .verification, not top-level)
           TAG_TYPE=$(gh api repos/"$REPO"/git/tags/"$TAG_OBJECT" --jq '.object.type' 2>/dev/null || echo "")
-          TAG_SIGNATURE=$(gh api repos/"$REPO"/git/tags/"$TAG_OBJECT" --jq '.signature' 2>/dev/null || echo "")
+          TAG_VERIFIED=$(gh api repos/"$REPO"/git/tags/"$TAG_OBJECT" --jq '.verification.verified' 2>/dev/null || echo "")
           
           if [ "$TAG_TYPE" != "commit" ]; then
             echo "ERROR: Tag $TAG is not annotated (type: $TAG_TYPE). Lightweight tags are not allowed."
             exit 1
           fi
           
-          if [ -z "$TAG_SIGNATURE" ] || [ "$TAG_SIGNATURE" = "null" ]; then
-            echo "ERROR: Tag $TAG is not GPG-signed. All releases must be signed."
+          if [ "$TAG_VERIFIED" != "true" ]; then
+            echo "ERROR: Tag $TAG is not GPG-signed or signature is invalid. All releases must be signed."
             exit 1
           fi
           


### PR DESCRIPTION
## Summary

The GitHub API nests tag signature data under `.verification`, not at the top level. The release workflow was checking `.signature` which always returned `null`, causing all signed tag releases to fail.

## Changes

- `.signature` -> `.verification.verified` (boolean check, lets GitHub do the crypto validation)
- Variable renamed `TAG_SIGNATURE` -> `TAG_VERIFIED` to match semantics
- Error message updated to cover both unsigned and invalid signature cases

## Verification

Confirmed via GitHub API that the existing `v0.11.0` tag:
- `.signature` returns `null` (wrong path)
- `.verification.verified` returns `true` (correct path)

```bash
gh api repos/clouatre-labs/math-mcp-learning-server/git/tags/$TAG_OBJECT --jq '.signature // "NULL"'
# NULL

gh api repos/clouatre-labs/math-mcp-learning-server/git/tags/$TAG_OBJECT --jq '.verification.verified'
# true
```

## Context

Fixes the v0.11.0 release workflow failure (run 22047442931). After merging, the v0.11.0 tag will be deleted and re-created on the updated main to trigger a clean release.