### PR TITLE
fix(ci): add contents:write permission for release and attestation jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
     name: Create GitHub release
     needs: verify-tag-signature
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       dry_run: ${{ steps.dry_run.outputs.dry_run }}
@@ -118,7 +120,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-      contents: read
+      contents: write
+      attestations: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Problem

The release workflow fails with `HTTP 403: Resource not accessible by integration` when creating GitHub releases and attesting build provenance.

**Root cause:** The `create-release` job had no `permissions` block (defaulting to read-only), and `build-and-attest` only had `contents: read`.

## Fix

- `create-release`: add `permissions: contents: write` (required by `taiki-e/create-gh-release-action`)
- `build-and-attest`: upgrade to `contents: write` and add `attestations: write` (required by `actions/attest-build-provenance`)

## Verification

- `actionlint` passes
- Minimal permission grants (only the two jobs that need write access)
- `publish` and `mcp-registry` jobs remain `contents: read`

Blocked the v0.11.0 release (runs #22047442931, #22047526307).