### PR TITLE
fix(ci): add build-and-attest dependency to publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: create-release
+    needs: [create-release, build-and-attest]
     runs-on: ubuntu-24.04
     if: needs.create-release.outputs.dry_run != 'true'
     environment:


### PR DESCRIPTION
## Problem

The `publish` job had `needs: create-release` but was missing `build-and-attest` as a dependency. This caused it to run in parallel with `build-and-attest`, attempting to download the `release-dists` artifact before it was uploaded.

**Error:** `Artifact not found for name: release-dists`

## Fix

Change `publish.needs` from `create-release` to `[create-release, build-and-attest]` so the artifact exists before download.

## Job dependency graph (after fix)

```
verify-tag-signature -> create-release -> build-and-attest -> publish -> mcp-registry
```

## Blocked release

This is the third fix to the release workflow needed for v0.11.0:
1. #196 -- GPG signature field path (`.signature` -> `.verification.verified`)
2. #197 -- Missing `contents: write` permission for release creation
3. This PR -- Missing job dependency causing artifact not found