### PR TITLE
docs: remove broken links from README and SUBMISSION_GUIDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Educational MCP server demonstrating persistent workspace patterns and mathemati
 **Available on:**
 - [Official MCP Registry](https://registry.modelcontextprotocol.io/) - `io.github.clouatre-labs/math-mcp-learning-server`
 - [PyPI](https://pypi.org/project/math-mcp-learning-server/) - `math-mcp-learning-server`
-- [Prefect Horizon](https://horizon.prefect.io/app/math-mcp) - No installation required
 
 ## Requirements
 

--- a/docs/SUBMISSION_GUIDE.md
+++ b/docs/SUBMISSION_GUIDE.md
@@ -2,7 +2,7 @@
 
 Educational MCP server with 12 math/stats tools, persistent workspace, and cloud hosting. Demonstrates FastMCP 2.0 best practices with 86% test coverage.
 
-**Links:** [PyPI](https://pypi.org/project/math-mcp-learning-server/) | [Cloud](https://math-mcp.fastmcp.app/mcp) | [GitHub](https://github.com/clouatre-labs/math-mcp-learning-server)
+**Links:** [PyPI](https://pypi.org/project/math-mcp-learning-server/) | [GitHub](https://github.com/clouatre-labs/math-mcp-learning-server)
 
 ---
 


### PR DESCRIPTION
Remove two broken links:

- **README.md**: Removed `[Prefect Horizon](https://horizon.prefect.io/app/math-mcp)` from the "Available on" list (returns 404)
- **docs/SUBMISSION_GUIDE.md**: Removed `[Cloud](https://math-mcp.fastmcp.app/mcp)` from the links bar (valid MCP endpoint, not a browser-accessible URL)