### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.11.0"
+version = "0.11.1"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
Bump version for patch release v0.11.1.

Includes fix from #202 (revert ProcessPoolExecutor to ThreadPoolExecutor for Lambda compatibility).

Closes #201