### PR TITLE
docs: refresh README with corrected counts and flat structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <!-- mcp-name: io.github.clouatre-labs/math-mcp-learning-server -->
 
-Educational MCP server demonstrating persistent workspace patterns and mathematical operations. Built with [FastMCP 2.0](https://github.com/jlowin/fastmcp) and the official [Model Context Protocol Python SDK](https://github.com/modelcontextprotocol/python-sdk).
+Educational MCP server with 17 tools, persistent workspace, and cloud hosting. Built with [FastMCP 2.0](https://github.com/jlowin/fastmcp) and the official [Model Context Protocol Python SDK](https://github.com/modelcontextprotocol/python-sdk).
 
 **Available on:**
 - [Official MCP Registry](https://registry.modelcontextprotocol.io/) - `io.github.clouatre-labs/math-mcp-learning-server`
@@ -74,81 +74,42 @@ uv pip install math-mcp-learning-server[plotting]
 uv pip install math-mcp-learning-server[scientific,plotting]
 ```
 
-## Features
+## Tools
 
-- **Cross-Session Persistence**: Variables survive server restarts and session changes
-- **Safe Expression Evaluation**: Secure mathematical expression parsing with security logging
-- **Statistical Analysis**: Mean, median, mode, standard deviation, variance
-- **Financial Calculations**: Compound interest with formatted output
-- **Unit Conversions**: Length, weight, temperature
-- **Function Plotting**: Base64-encoded PNG plots (matplotlib)
-- **Statistical Histograms**: Distribution visualization with indicators
-- **Type Safety**: Full Pydantic validation for all inputs
-- **Comprehensive Testing**: Complete coverage with security validation
-- **Cross-Platform Storage**: Windows, macOS, Linux support
+| Category | Tool | Description |
+|----------|------|-------------|
+| **Workspace** | `save_calculation` | Save calculations to persistent storage |
+| | `load_variable` | Retrieve previously saved calculations |
+| **Math** | `calculate` | Safely evaluate mathematical expressions |
+| | `statistics` | Statistical analysis (mean, median, mode, std_dev, variance) |
+| | `compound_interest` | Calculate compound interest for investments |
+| | `convert_units` | Convert between units (length, weight, temperature) |
+| **Matrix** | `matrix_multiply` | Multiply two matrices |
+| | `matrix_transpose` | Transpose a matrix |
+| | `matrix_determinant` | Calculate matrix determinant |
+| | `matrix_inverse` | Calculate matrix inverse |
+| | `matrix_eigenvalues` | Calculate eigenvalues |
+| **Visualization** | `plot_function` | Plot mathematical functions |
+| | `create_histogram` | Create statistical histograms |
+| | `plot_line_chart` | Create line charts |
+| | `plot_scatter_chart` | Create scatter plots |
+| | `plot_box_plot` | Create box plots |
+| | `plot_financial_line` | Create financial line charts |
 
-## MCP Implementation
+## Resources
 
-**Primitives:**
-- **Tools**: 17 tools for mathematical operations, persistence, visualization, and matrix operations
-- **Resources**: 1 resource (`math://workspace`) for viewing persistent workspace
-- **Prompts**: 2 prompts (`math_tutor`, `formula_explainer`) for educational interactions
+- `math://workspace` - Persistent calculation workspace summary
+- `math://history` - Chronological calculation history
+- `math://functions` - Available mathematical functions reference
+- `math://constants/{constant}` - Mathematical constants (pi, e, golden_ratio, etc.)
+- `math://test` - Server health check
 
-**Transports:**
-- **stdio** - Standard input/output for local clients
-- **HTTP/SSE** - Server-Sent Events for cloud/web clients
+## Prompts
 
-Workspace persists across all transport modes and sessions.
+- `math_tutor` - Structured tutoring prompts (configurable difficulty)
+- `formula_explainer` - Formula explanation with step-by-step breakdowns
 
-## Available Tools
-
-### Persistent Workspace Tools
-- `save_calculation`: Save calculations to persistent storage for cross-session access
-- `load_variable`: Access previously saved calculations from any MCP client session
-
-### Mathematical Tools
-- `calculate`: Safely evaluate mathematical expressions (supports basic ops and math functions)
-- `statistics`: Perform statistical calculations (mean, median, mode, std_dev, variance)
-- `compound_interest`: Calculate compound interest for investments
-- `convert_units`: Convert between units (length, weight, temperature)
-
-### Visualization Tools
-- `plot_function`: Generate mathematical function plots (base64-encoded PNG)
-- `create_histogram`: Create statistical histograms with distribution analysis
-- `plot_line_chart`: Create line charts for sequential data visualization
-- `plot_scatter_chart`: Create scatter plots for relationship analysis
-- `plot_box_plot`: Create box plots for statistical distribution comparison
-- `plot_financial_line`: Create financial trend plots with bullish/bearish/volatile patterns
-
-### Matrix Operations (requires `[scientific]` extra)
-- `matrix_multiply`: Multiply two matrices with dimension validation
-- `matrix_transpose`: Transpose a matrix (swap rows and columns)
-- `matrix_determinant`: Calculate determinant of square matrices
-- `matrix_inverse`: Compute matrix inverse with singular matrix detection
-- `matrix_eigenvalues`: Calculate eigenvalues (supports complex numbers)
-
-**Note**: Matrix operations require NumPy. Install with `uv pip install math-mcp-learning-server[scientific]`
-
-See [Usage Examples](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/EXAMPLES.md) for detailed examples of each tool.
-
-## Available Prompts
-
-### Educational Prompts
-- `math_tutor`: Generate structured tutoring prompts for mathematical concepts (configurable difficulty level)
-- `formula_explainer`: Generate comprehensive formula explanation prompts with step-by-step breakdowns
-
-See [Usage Examples](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/EXAMPLES.md) for detailed examples of each prompt.
-
-## Available Resources
-
-### `math://workspace`
-View your complete persistent workspace with all saved calculations, metadata, and statistics.
-
-**Returns:**
-- All saved variables with expressions and results
-- Educational metadata (difficulty, topic)
-- Workspace statistics (total calculations, session count)
-- Timestamps for tracking calculation history
+See [Usage Examples](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/EXAMPLES.md) for detailed examples.
 
 ## Development
 
@@ -175,8 +136,7 @@ uv run pytest tests/ --cov=src --cov-report=html --cov-report=term
 uv run pytest tests/test_matrix_operations.py -v
 ```
 
-**Test Suite:** 126 tests across 5 categories (HTTP, Math, Matrix, Persistence, Visualization)
-**Coverage:** See detailed [testing documentation](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/testing/)
+**Test Suite:** 154 tests across 6 categories (Agent Card, HTTP Integration, Math, Matrix, Persistence, Visualization)
 
 ### Code Quality
 
@@ -191,45 +151,16 @@ uv run ruff format --check
 uv run ruff check --select S
 ```
 
-### Contributing
-
-See [CONTRIBUTING.md](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md) for guidelines on submitting changes.
-
-## Documentation
-
-- **[Cloud Deployment Guide](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/CLOUD_DEPLOYMENT.md)**: Prefect Horizon deployment instructions and configuration
-- **[Usage Examples](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/EXAMPLES.md)**: Practical examples for all tools and resources
-- **[Contributing Guidelines](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md)**: Development workflow, code standards, and testing procedures
-- **[Roadmap](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/ROADMAP.md)**: Planned features and enhancement opportunities
-- **[Code of Conduct](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CODE_OF_CONDUCT.md)**: Community guidelines and expectations
-
 ## Security
 
-### Safe Expression Evaluation
+The `calculate` tool uses restricted `eval()` with a whitelist of allowed characters and functions, restricted global scope (only `math` module and `abs`), and no access to dangerous built-ins or imports. All tool inputs are validated with Pydantic models. File operations are restricted to the designated workspace directory. Complete type hints and validation are enforced for all operations.
 
-The `calculate` tool uses restricted `eval()` with:
-- Whitelist of allowed characters and functions
-- Restricted global scope (only `math` module and `abs`)
-- No access to dangerous built-ins or imports
-- Security logging for potentially dangerous attempts
+## Links
 
-### MCP Security Best Practices
-
-- **Input Validation**: All tool inputs validated with Pydantic models
-- **Error Handling**: Structured errors without exposing sensitive information
-- **Least Privilege**: File operations restricted to designated workspace directory
-- **Type Safety**: Complete type hints and validation for all operations
-
-## Contributing
-
-We welcome contributions! See [CONTRIBUTING.md](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md) for development workflow, code standards, and testing procedures.
-
-For maintainers: See [MAINTAINER_GUIDE.md](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/.github/MAINTAINER_GUIDE.md) for release procedures.
-
-## Code of Conduct
-
-This project adheres to the [Contributor Covenant Code of Conduct](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to hugues+mcp-coc@linux.com.
-
-## License
-
-[MIT License](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/LICENSE) - Full license details available in the LICENSE file.
+- [Cloud Deployment Guide](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/CLOUD_DEPLOYMENT.md)
+- [Usage Examples](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/docs/EXAMPLES.md)
+- [Contributing Guidelines](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md)
+- [Maintainer Guide](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/.github/MAINTAINER_GUIDE.md)
+- [Roadmap](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/ROADMAP.md)
+- [Code of Conduct](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CODE_OF_CONDUCT.md)
+- [License](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/LICENSE)

--- a/docs/SUBMISSION_GUIDE.md
+++ b/docs/SUBMISSION_GUIDE.md
@@ -1,6 +1,6 @@
 # MCP Server Publication Guide
 
-Educational MCP server with 12 math/stats tools, persistent workspace, and cloud hosting. Demonstrates FastMCP 2.0 best practices with 86% test coverage.
+Educational MCP server with 17 tools, persistent workspace, and cloud hosting. Demonstrates FastMCP 2.0 best practices.
 
 **Links:** [PyPI](https://pypi.org/project/math-mcp-learning-server/) | [GitHub](https://github.com/clouatre-labs/math-mcp-learning-server)
 


### PR DESCRIPTION
## Summary

Rewrites README.md from 235 to 166 lines with corrected facts and improved structure aligned with best-in-class MCP server READMEs.

## Changes

### README.md
- **Fixed counts**: 17 tools (was unlisted per-category), 5 resources (was 1), 154 tests (was 126), 6 categories (was 5)
- **Flat tool table**: Replaced nested bullet lists with a scannable markdown table grouped by category
- **Removed duplicates**: Contributing section appeared twice, Code of Conduct had its own section duplicating the Links reference
- **Consolidated Security**: Two subsections merged into a single paragraph
- **Removed MCP Implementation section**: Primitives/transports detail folded into intro line and tool/resource/prompt sections
- **Added all 5 resources**: workspace, history, functions, constants, test

### docs/SUBMISSION_GUIDE.md
- Fixed tool count: 12 -> 17
- Removed stale "86% test coverage" claim

## Testing
- Docs-only change, no code modified
- Verified all 17 tool decorators, 5 resource decorators, 2 prompt decorators match README claims
- Verified 154 tests collected across 6 test files
- All badge URLs and documentation links preserved
- Security scan: 0 findings