### PR TITLE
chore: add glama.json for registry ownership claim

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "clouatre"
+  ]
+}


### PR DESCRIPTION
Adds `glama.json` to the repo root to claim ownership of the server listing on [Glama.ai](https://glama.ai/mcp/connectors/io.github.clouatre-labs/math-mcp-learning-server).

Per [Glama docs](https://glama.ai/blog/2025-07-08-what-is-glamajson), org-hosted repos must include this file with a maintainer email matching the Glama account.

No code changes. Single config file addition.