### PR TITLE
chore: remove deprecated FastMCP 2.x patterns

### DIFF
--- a/src/math_mcp/server.py
+++ b/src/math_mcp/server.py
@@ -177,7 +177,7 @@ async def agent_card_endpoint(request) -> JSONResponse:
 def main() -> None:
     """Main entry point supporting multiple transports.
 
-    Supports stdio, sse, and streamable-http transports. The A2A agent
+    Supports stdio and streamable-http transports. The A2A agent
     card endpoint is automatically registered via @mcp.custom_route()
     and available on all HTTP-based transports.
     """
@@ -185,10 +185,10 @@ def main() -> None:
     from typing import Literal, cast
 
     # Parse command line arguments for transport type
-    transport: Literal["stdio", "sse", "streamable-http"] = "stdio"  # default
+    transport: Literal["stdio", "streamable-http"] = "stdio"  # default
     if len(sys.argv) > 1:
-        if sys.argv[1] in ["stdio", "sse", "streamable-http"]:
-            transport = cast(Literal["stdio", "sse", "streamable-http"], sys.argv[1])
+        if sys.argv[1] in ["stdio", "streamable-http"]:
+            transport = cast(Literal["stdio", "streamable-http"], sys.argv[1])
 
     # Run the MCP server with the specified transport
     mcp.run(transport=transport)

--- a/src/math_mcp/tools/calculate.py
+++ b/src/math_mcp/tools/calculate.py
@@ -30,7 +30,7 @@ calculate_mcp = FastMCP(name="Calculate Tools")
 @validated_tool
 async def calculate(
     expression: Annotated[str, Field(max_length=MAX_EXPRESSION_LENGTH)],
-    ctx: SkipValidation[Context],
+    ctx: SkipValidation[Context | None] = None,
 ) -> dict[str, Any]:
     """Safely evaluate mathematical expressions with support for basic operations and math functions.
 
@@ -44,7 +44,8 @@ async def calculate(
     """
     from datetime import datetime
 
-    await ctx.info(f"Calculating expression: {expression}")
+    if ctx:
+        await ctx.info(f"Calculating expression: {expression}")
 
     result = await evaluate_with_timeout(expression)
     timestamp = datetime.now().isoformat()
@@ -57,7 +58,8 @@ async def calculate(
         "result": result,
         "timestamp": timestamp,
     }
-    ctx.request_context.lifespan_context.calculation_history.append(history_entry)
+    if ctx and ctx.request_context:
+        ctx.request_context.lifespan_context.calculation_history.append(history_entry)
 
     return {
         "content": [
@@ -81,7 +83,7 @@ async def calculate(
 async def statistics(
     numbers: Annotated[list[float], Field(max_length=MAX_ARRAY_SIZE)],
     operation: str,
-    ctx: SkipValidation[Context],
+    ctx: SkipValidation[Context | None] = None,
 ) -> dict[str, Any]:
     """Perform statistical calculations on a list of numbers.
 
@@ -92,7 +94,8 @@ async def statistics(
             f"Invalid operation: {operation}. Allowed: {', '.join(sorted(ALLOWED_OPERATIONS))}"
         )
 
-    await ctx.info(f"Performing {operation} on {len(numbers)} data points")
+    if ctx:
+        await ctx.info(f"Performing {operation} on {len(numbers)} data points")
 
     import statistics as stats
 

--- a/src/math_mcp/tools/persistence.py
+++ b/src/math_mcp/tools/persistence.py
@@ -36,7 +36,7 @@ async def save_calculation(
     name: Annotated[str, Field(max_length=MAX_VARIABLE_NAME_LENGTH)],
     expression: Annotated[str, Field(max_length=MAX_EXPRESSION_LENGTH)],
     result: float,
-    ctx: SkipValidation[Context],
+    ctx: SkipValidation[Context | None] = None,
 ) -> dict[str, Any]:
     """Save calculation to persistent workspace (survives restarts).
 
@@ -51,7 +51,8 @@ async def save_calculation(
     """
     validate_variable_name(name)
 
-    await ctx.info(f"Saving calculation '{name}' = {result}")
+    if ctx:
+        await ctx.info(f"Saving calculation '{name}' = {result}")
 
     difficulty = _classify_expression_difficulty(expression)
     topic = _classify_expression_topic(expression)
@@ -59,7 +60,9 @@ async def save_calculation(
     metadata = {
         "difficulty": difficulty,
         "topic": topic,
-        "session_id": id(ctx.request_context.lifespan_context),
+        "session_id": id(ctx.request_context.lifespan_context)
+        if ctx and ctx.request_context
+        else None,
     }
 
     from math_mcp.persistence.workspace import _workspace_manager
@@ -73,7 +76,8 @@ async def save_calculation(
         "result": result,
         "timestamp": datetime.now().isoformat(),
     }
-    ctx.request_context.lifespan_context.calculation_history.append(history_entry)
+    if ctx and ctx.request_context:
+        ctx.request_context.lifespan_context.calculation_history.append(history_entry)
 
     return {
         "content": [
@@ -93,7 +97,7 @@ async def save_calculation(
 
 
 @persistence_mcp.tool()
-async def load_variable(name: str, ctx: Context) -> dict[str, Any]:
+async def load_variable(name: str, ctx: SkipValidation[Context | None] = None) -> dict[str, Any]:
     """Load previously saved calculation result from workspace.
 
     Args:
@@ -103,7 +107,8 @@ async def load_variable(name: str, ctx: Context) -> dict[str, Any]:
         load_variable("portfolio_return")  # Returns saved calculation
         load_variable("circle_area")       # Access across sessions
     """
-    await ctx.info(f"Loading variable '{name}'")
+    if ctx:
+        await ctx.info(f"Loading variable '{name}'")
     from math_mcp.persistence.workspace import _workspace_manager
 
     result_data = _workspace_manager.load_variable(name)
@@ -135,7 +140,8 @@ async def load_variable(name: str, ctx: Context) -> dict[str, Any]:
         "result": result_data["result"],
         "timestamp": datetime.now().isoformat(),
     }
-    ctx.request_context.lifespan_context.calculation_history.append(history_entry)
+    if ctx and ctx.request_context:
+        ctx.request_context.lifespan_context.calculation_history.append(history_entry)
 
     return {
         "content": [


### PR DESCRIPTION
## Summary

Fixes #207. Minimal scope — 3 files, 25 insertions, 16 deletions, no logic changes beyond null guards.

## Changes

**`calculate.py`**
- `calculate()`: `SkipValidation[Context]` → `SkipValidation[Context | None] = None`
- `statistics()`: same
- `if ctx:` guard around `ctx.info()`
- `if ctx and ctx.request_context:` guard before `lifespan_context` access

**`persistence.py`**
- `save_calculation()`: `SkipValidation[Context]` → `SkipValidation[Context | None] = None`
- `load_variable()`: `Context` → `SkipValidation[Context | None] = None`
- `if ctx:` guards around all `ctx.info()` calls
- `if ctx and ctx.request_context:` guards before `lifespan_context` access
- `session_id` uses conditional expression: `id(...) if ctx and ctx.request_context else None`

**`server.py`**
- SSE transport removed from type literal and argument check
- Docstring updated

## What was not changed

- `visualization.py` — already uses `SkipValidation[Context | None]` pattern, untouched
- `matrix.py` — same, untouched
- `storage.py` — untouched
- `tests/` — zero test changes; all `MockContext` fixtures and behavioral assertions (`info_logs`, `calculation_history`, `session_id`) preserved exactly

## Testing

```
129 passed, 0 failed
ruff format: clean
ruff check: clean
pyright: clean (6 pre-existing reportMissingImports for matplotlib/numpy optional deps, unrelated)
gitleaks: no leaks found
```

## Relation to PR #210

PR #210 solved the same issue but expanded scope significantly (10 files, 126 insertions, 201 deletions, logic regressions, dropped test assertions). This PR is the minimal correct fix as specified in #207.