### PR TITLE
chore: update metadata for FastMCP 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <!-- mcp-name: io.github.clouatre-labs/math-mcp-learning-server -->
 
-Educational MCP server with 17 tools, persistent workspace, and cloud hosting. Built with [FastMCP 2.0](https://github.com/jlowin/fastmcp) and the official [Model Context Protocol Python SDK](https://github.com/modelcontextprotocol/python-sdk).
+Educational MCP server with 17 tools, persistent workspace, and cloud hosting. Built with [FastMCP 3.0](https://github.com/PrefectHQ/fastmcp) and the official [Model Context Protocol Python SDK](https://github.com/modelcontextprotocol/python-sdk).
 
 **Available on:**
 - [Official MCP Registry](https://registry.modelcontextprotocol.io/) - `io.github.clouatre-labs/math-mcp-learning-server`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,31 +12,23 @@ Build capabilities LLMs lack natively: **persistent state**, **visual output**, 
 - **Visualization** (v0.6.0--v0.7.0) -- Function plots, histograms, scatter/line/box/financial charts
 - **Production Hardening** (v0.9.0) -- Rate limiting, input validation, structured logging, CI matrix
 - **Matrix Operations** (v0.10.0) -- Multiply, transpose, determinant, inverse, eigenvalues via NumPy
+- **FastMCP 3.0 Upgrade** (v0.11.0) -- Upgraded from FastMCP 2.x to 3.0; migrated to [PrefectHQ/fastmcp](https://github.com/PrefectHQ/fastmcp); adopted streamable-http transport
 
 ## Upcoming
-
-### FastMCP 3.0 Upgrade
-
-**Status:** Waiting for stable release (beta 2 released Feb 8, 2026).
-
-FastMCP 3.0 is designed as a low-friction upgrade. Per the [official upgrade guide](https://gofastmcp.com/development/upgrade-guide), most servers need no code changes. Our codebase uses none of the affected breaking changes (WSTransport, auth provider env vars, component enable/disable API, listing-methods-as-dicts, PromptMessage, sync ctx.set_state/get_state).
-
-New capabilities available after upgrade:
-- Providers and Transforms (component-level composition and filtering)
-- Per-component authorization and versioning
-- Hot reload during development
-- OpenTelemetry instrumentation
-- Decorated functions remain directly callable (useful for testing)
-
-**Migration scope:** Likely minimal. Our middleware (`add_middleware()`) is unchanged in 3.0. Primary effort is testing, not rewriting.
-
-**Action:** Track [FastMCP releases](https://github.com/jlowin/fastmcp/releases). Upgrade when stable lands.
 
 ### Test Coverage Expansion
 
 - MCP resources and prompts testing (currently untested via protocol)
 - End-to-end workflow tests (calculate, save, load, visualize)
 - Property-based testing with Hypothesis
+
+### FastMCP 3.0 Features
+
+New capabilities available with the 3.0 upgrade:
+- ResponseLimitingMiddleware for output size control
+- `ctx.transport` for transport-aware tool behavior
+- Lifespan composition for modular startup/shutdown
+- OpenTelemetry instrumentation support
 
 ### Production Hardening
 
@@ -53,7 +45,7 @@ New capabilities available after upgrade:
 ## Architecture Principles
 
 - **Single server** -- one focused MCP, not multiple servers
-- **Transport agnostic** -- same functionality across stdio/HTTP/SSE
+- **Transport agnostic** -- same functionality across stdio/HTTP (streamable-http)
 - **Progressive enhancement** -- advanced features are optional extras
 - **Minimal core dependencies** -- keep base installation lightweight
 - **Graceful degradation** -- clear errors when optional features are unavailable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "math-mcp-learning-server"
 version = "0.11.1"
-description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
+description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 3.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.14"
 license = "MIT"


### PR DESCRIPTION
## Summary

Update all project metadata to reflect the FastMCP 3.0 upgrade. Code was already upgraded to 3.0 in #212; this PR aligns documentation and repo metadata.

## Changes

- **README.md**: Update FastMCP reference from 2.0 to 3.0, update link from jlowin/fastmcp to PrefectHQ/fastmcp
- **pyproject.toml**: Update description to reference FastMCP 3.0 best practices
- **ROADMAP.md**: Move FastMCP 3.0 Upgrade to Completed (v0.11.0), update transport reference from SSE to streamable-http, add upcoming FastMCP 3.0 feature exploration items

## External

- awesome-mcp-servers PR #2151 opened to update listing

## Testing

136 tests passing. Documentation-only changes; no code modified.

Closes #209