### PR TITLE
chore: release 0.11.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.11.1"
+version = "0.11.2"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 3.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
Bump version to 0.11.2.

Follows #215 (fix: remove redundant OSError subclasses from exception handlers).