### PR TITLE
refactor: add ctx.report_progress to statistics tool

### DIFF
--- a/src/math_mcp/tools/calculate.py
+++ b/src/math_mcp/tools/calculate.py
@@ -95,12 +95,18 @@ async def statistics(
         )
 
     if ctx:
+        await ctx.report_progress(0, 2, "Validating input")
+
+    if ctx:
         await ctx.info(f"Performing {operation} on {len(numbers)} data points")
 
     import statistics as stats
 
     if not numbers:
         raise ValueError("Cannot calculate statistics on empty list")
+
+    if ctx:
+        await ctx.report_progress(1, 2, "Computing statistics")
 
     operations = {
         "mean": stats.mean,
@@ -112,6 +118,9 @@ async def statistics(
 
     result = operations[operation](numbers)
     result_float = float(result)
+
+    if ctx:
+        await ctx.report_progress(2, 2, "Complete")
 
     difficulty = (
         "advanced"

--- a/tests/test_math_operations.py
+++ b/tests/test_math_operations.py
@@ -125,10 +125,15 @@ async def test_statistics_tool():
     class MockContext:
         def __init__(self):
             self.info_logs = []
+            self.progress_reports = []
 
         async def info(self, message: str):
             """Mock info logging."""
             self.info_logs.append(message)
+
+        async def report_progress(self, current: int, total: int, message: str = "") -> None:
+            """Mock progress reporting."""
+            self.progress_reports.append((current, total, message))
 
     ctx = MockContext()
 
@@ -284,10 +289,15 @@ async def test_statistical_edge_cases():
     class MockContext:
         def __init__(self):
             self.info_logs = []
+            self.progress_reports = []
 
         async def info(self, message: str):
             """Mock info logging."""
             self.info_logs.append(message)
+
+        async def report_progress(self, current: int, total: int, message: str = "") -> None:
+            """Mock progress reporting."""
+            self.progress_reports.append((current, total, message))
 
     ctx = MockContext()
 
@@ -480,8 +490,15 @@ async def test_array_size_validation():
 
     # Mock context
     class MockContext:
+        def __init__(self):
+            self.progress_reports = []
+
         async def info(self, message: str):
             pass
+
+        async def report_progress(self, current: int, total: int, message: str = "") -> None:
+            """Mock progress reporting."""
+            self.progress_reports.append((current, total, message))
 
     ctx = MockContext()
 
@@ -502,8 +519,15 @@ async def test_operation_whitelist_validation():
 
     # Mock context
     class MockContext:
+        def __init__(self):
+            self.progress_reports = []
+
         async def info(self, message: str):
             pass
+
+        async def report_progress(self, current: int, total: int, message: str = "") -> None:
+            """Mock progress reporting."""
+            self.progress_reports.append((current, total, message))
 
     ctx = MockContext()
 
@@ -680,8 +704,15 @@ async def test_empty_input_validation():
 
     # Mock context
     class MockContext:
+        def __init__(self):
+            self.progress_reports = []
+
         async def info(self, message: str):
             pass
+
+        async def report_progress(self, current: int, total: int, message: str = "") -> None:
+            """Mock progress reporting."""
+            self.progress_reports.append((current, total, message))
 
     ctx = MockContext()
 

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ wheels = [
 
 [[package]]
 name = "math-mcp-learning-server"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Add three-stage progress reporting to `statistics()` in `calculate.py`, matching the existing pattern used in `matrix_inverse` and `matrix_eigenvalues` in `matrix.py`.

## Changes

- `src/math_mcp/tools/calculate.py`: Add 3 `await ctx.report_progress()` calls inside `statistics()`, guarded with `if ctx:`
  - Stage 0/2: Validating input (after operation validation)
  - Stage 1/2: Computing statistics (after empty-list check)
  - Stage 2/2: Complete (after result computation)
- `tests/test_math_operations.py`: Extend `MockContext` fixtures in affected test functions with `report_progress` method and `progress_reports` list

## Constraints honored

- `ctx` parameter remains optional; all calls guarded with `if ctx:`
- `calculate()`, `compound_interest()`, and `convert_units()` are unchanged
- No new test functions added

## Testing

- 154 tests passed, 0 failed
- Ruff: clean
- Pyright: clean
- Gitleaks: 0 findings

Closes #221