### PR TITLE
feat(models): typed tool responses via Pydantic BaseModel

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,6 +98,20 @@ graph TD
 - **Lifespan Context**: `@asynccontextmanager` in server.py manages AppContext (in-memory state) across the server lifetime. Lost on restart; use workspace persistence for recovery.
 - **Optional Context**: All tools accept `ctx: SkipValidation[Context | None] = None` (never required). Guarded with `if ctx:` before use; enables tools to work with or without MCP runtime context.
 
+## Module Map
+
+| Module | Purpose |
+|--------|---------|
+| `server.py` | Composition root, middleware stack, lifespan context |
+| `models.py` | Pydantic BaseModel response types (CalculationResult, MatrixResult, WorkspaceResult, VisualizationResult) |
+| `tools/calculate.py` | Math operations (calculate, statistics, compound_interest, convert_units) |
+| `tools/matrix.py` | Matrix operations (multiply, transpose, determinant, inverse, eigenvalues) |
+| `tools/persistence.py` | Workspace persistence (save_calculation, load_variable) |
+| `tools/visualization.py` | Plotting tools (plot_function, create_histogram, plot_line_chart, plot_scatter_chart, plot_box_plot, plot_financial_line) |
+| `resources.py` | MCP resources (math_constants, workspace) and prompts (math_tutor, formula_explainer) |
+| `eval.py` | Restricted eval() sandbox with character/function whitelist |
+| `settings.py` | Configuration (rate limits, workspace paths, feature flags) |
+
 ## Prompts
 
 FastMCP's `@mcp.prompt()` decorator registers reusable prompt templates that Claude can invoke. Math MCP Server provides two prompts via the resources sub-server: `math_tutor` (structured tutoring prompts with configurable difficulty and examples) and `formula_explainer` (detailed formula breakdowns with variable definitions, context, and real-world applications). See [FastMCP Prompts Documentation](https://gofastmcp.com/servers/prompts) for details.

--- a/src/math_mcp/models.py
+++ b/src/math_mcp/models.py
@@ -1,0 +1,79 @@
+"""Typed response models for MCP tools.
+
+This module defines Pydantic BaseModel subclasses for all tool return types.
+Typed returns improve MCP client schema generation and provide IDE autocomplete
+for downstream consumers. Each model uses pure attribute access (no __getitem__)
+and keeps content items as plain dicts to avoid over-modeling MCP protocol blobs.
+
+Educational note: BaseModel serialization via model_dump() produces identical
+JSON to the previous dict-based returns, but with the added benefit of
+runtime validation and static type checking.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CalculationResult(BaseModel):
+    """Result of a mathematical calculation.
+
+    Used by: calculate, statistics, compound_interest, convert_units tools.
+
+    Attributes:
+        content: List of content items (text, images, etc.) for MCP protocol.
+                 Items remain as plain dicts to preserve MCP flexibility.
+    """
+
+    content: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="MCP content items (text, images, etc.)",
+    )
+
+
+class MatrixResult(BaseModel):
+    """Result of a matrix operation.
+
+    Used by: all 5 matrix tools (add, multiply, transpose, determinant, inverse).
+
+    Attributes:
+        content: List of content items describing the matrix operation result.
+                 Items remain as plain dicts.
+    """
+
+    content: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="MCP content items with matrix data and visualization",
+    )
+
+
+class WorkspaceResult(BaseModel):
+    """Result of a workspace operation (save/load).
+
+    Used by: save_calculation, load_variable tools.
+
+    Attributes:
+        content: List of content items for MCP protocol.
+                 Items remain as plain dicts to preserve MCP flexibility.
+    """
+
+    content: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="MCP content items",
+    )
+
+
+class VisualizationResult(BaseModel):
+    """Result of a visualization operation.
+
+    Used by: all 6 visualization tools (plot, scatter, histogram, heatmap, 3d_surface, mandelbrot).
+
+    Attributes:
+        content: List of content items with plot images and descriptions.
+                 Items remain as plain dicts.
+    """
+
+    content: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="MCP content items with plot images and metadata",
+    )

--- a/src/math_mcp/tools/calculate.py
+++ b/src/math_mcp/tools/calculate.py
@@ -3,7 +3,7 @@ Calculate Tools Sub-Server
 FastMCP sub-server for mathematical calculations, statistics, and unit conversions.
 """
 
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastmcp import Context, FastMCP
 from pydantic import Field, SkipValidation
@@ -13,6 +13,7 @@ from math_mcp.eval import (
     convert_temperature,
     evaluate_with_timeout,
 )
+from math_mcp.models import CalculationResult
 from math_mcp.settings import (
     ALLOWED_OPERATIONS,
     MAX_ARRAY_SIZE,
@@ -31,7 +32,7 @@ calculate_mcp = FastMCP(name="Calculate Tools")
 async def calculate(
     expression: Annotated[str, Field(max_length=MAX_EXPRESSION_LENGTH)],
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> CalculationResult:
     """Safely evaluate mathematical expressions with support for basic operations and math functions.
 
     Supported operations: +, -, *, /, **, ()
@@ -51,8 +52,8 @@ async def calculate(
     timestamp = datetime.now().isoformat()
     difficulty = _classify_expression_difficulty(expression)
 
-    return {
-        "content": [
+    return CalculationResult(
+        content=[
             {
                 "type": "text",
                 "text": f"**Calculation:** {expression} = {result}",
@@ -63,7 +64,7 @@ async def calculate(
                 },
             }
         ]
-    }
+    )
 
 
 @calculate_mcp.tool(
@@ -74,7 +75,7 @@ async def statistics(
     numbers: Annotated[list[float], Field(max_length=MAX_ARRAY_SIZE)],
     operation: str,
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> CalculationResult:
     """Perform statistical calculations on a list of numbers.
 
     Available operations: mean, median, mode, std_dev, variance
@@ -120,8 +121,8 @@ async def statistics(
         else "basic"
     )
 
-    return {
-        "content": [
+    return CalculationResult(
+        content=[
             {
                 "type": "text",
                 "text": f"**{operation.title()}** of {len(numbers)} numbers: {result_float}",
@@ -133,7 +134,7 @@ async def statistics(
                 },
             }
         ]
-    }
+    )
 
 
 @calculate_mcp.tool()
@@ -143,7 +144,7 @@ async def compound_interest(
     time: float,
     compounds_per_year: int = 1,
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> CalculationResult:
     """Calculate compound interest for investments.
 
     Formula: A = P(1 + r/n)^(nt)
@@ -170,8 +171,8 @@ async def compound_interest(
     final_amount = principal * (1 + rate / compounds_per_year) ** (compounds_per_year * time)
     total_interest = final_amount - principal
 
-    return {
-        "content": [
+    return CalculationResult(
+        content=[
             {
                 "type": "text",
                 "text": f"**Compound Interest Calculation:**\nPrincipal: ${principal:,.2f}\nFinal Amount: ${final_amount:,.2f}\nTotal Interest Earned: ${total_interest:,.2f}",
@@ -183,7 +184,7 @@ async def compound_interest(
                 },
             }
         ]
-    }
+    )
 
 
 @calculate_mcp.tool()
@@ -193,7 +194,7 @@ async def convert_units(
     to_unit: str,
     unit_type: str,
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> CalculationResult:
     """Convert between different units of measurement.
 
     Supported unit types:
@@ -243,8 +244,8 @@ async def convert_units(
         base_value = value * from_factor
         result = base_value / to_factor
 
-    return {
-        "content": [
+    return CalculationResult(
+        content=[
             {
                 "type": "text",
                 "text": f"**Unit Conversion:** {value} {from_unit} = {result:.4g} {to_unit}",
@@ -257,4 +258,4 @@ async def convert_units(
                 },
             }
         ]
-    }
+    )

--- a/src/math_mcp/tools/matrix.py
+++ b/src/math_mcp/tools/matrix.py
@@ -10,6 +10,7 @@ from typing import Annotated, Any
 from fastmcp import Context, FastMCP
 from pydantic import Field, SkipValidation
 
+from math_mcp.models import MatrixResult
 from math_mcp.settings import MAX_ARRAY_SIZE, validated_tool
 
 # Try importing numpy for matrix operations
@@ -108,7 +109,7 @@ async def matrix_multiply(
     matrix_a: Annotated[list[list[float]], Field(max_length=MAX_ARRAY_SIZE)],
     matrix_b: Annotated[list[list[float]], Field(max_length=MAX_ARRAY_SIZE)],
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> MatrixResult:
     """Multiply two matrices (A × B).
 
     Args:
@@ -138,8 +139,8 @@ async def matrix_multiply(
 
         result = np.matmul(mat_a, mat_b)  # type: ignore
 
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Matrix Multiplication Result:**\n{_format_matrix(result)}",
@@ -151,11 +152,11 @@ async def matrix_multiply(
                     },
                 }
             ]
-        }
+        )
 
     except ValueError as e:
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Matrix Multiplication Error:** {str(e)}",
@@ -167,10 +168,10 @@ async def matrix_multiply(
                     },
                 }
             ]
-        }
+        )
     except Exception as e:
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Unexpected Error:** {str(e)}",
@@ -182,7 +183,7 @@ async def matrix_multiply(
                     },
                 }
             ]
-        }
+        )
 
 
 @matrix_mcp.tool(
@@ -196,7 +197,7 @@ async def matrix_multiply(
 async def matrix_transpose(
     matrix: Annotated[list[list[float]], Field(max_length=MAX_ARRAY_SIZE)],
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> MatrixResult:
     """Transpose a matrix (swap rows and columns).
 
     Args:
@@ -216,8 +217,8 @@ async def matrix_transpose(
         mat = _validate_matrix(matrix)
         result = mat.T  # type: ignore
 
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Matrix Transpose Result:**\n{_format_matrix(result)}",
@@ -230,11 +231,11 @@ async def matrix_transpose(
                     },
                 }
             ]
-        }
+        )
 
     except ValueError as e:
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Matrix Transpose Error:** {str(e)}",
@@ -246,10 +247,10 @@ async def matrix_transpose(
                     },
                 }
             ]
-        }
+        )
     except Exception as e:
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Unexpected Error:** {str(e)}",
@@ -261,7 +262,7 @@ async def matrix_transpose(
                     },
                 }
             ]
-        }
+        )
 
 
 @matrix_mcp.tool(
@@ -275,7 +276,7 @@ async def matrix_transpose(
 async def matrix_determinant(
     matrix: Annotated[list[list[float]], Field(max_length=MAX_ARRAY_SIZE)],
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> MatrixResult:
     """Calculate the determinant of a square matrix.
 
     Args:
@@ -302,8 +303,8 @@ async def matrix_determinant(
 
         det = la.det(mat)  # type: ignore
 
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Matrix Determinant:** {det:.6g}",
@@ -316,11 +317,11 @@ async def matrix_determinant(
                     },
                 }
             ]
-        }
+        )
 
     except ValueError as e:
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Matrix Determinant Error:** {str(e)}",
@@ -332,10 +333,10 @@ async def matrix_determinant(
                     },
                 }
             ]
-        }
+        )
     except Exception as e:
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Unexpected Error:** {str(e)}",
@@ -347,7 +348,7 @@ async def matrix_determinant(
                     },
                 }
             ]
-        }
+        )
 
 
 @matrix_mcp.tool(
@@ -361,7 +362,7 @@ async def matrix_determinant(
 async def matrix_inverse(
     matrix: Annotated[list[list[float]], Field(max_length=MAX_ARRAY_SIZE)],
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> MatrixResult:
     """Calculate the inverse of a square matrix.
 
     Args:
@@ -411,8 +412,8 @@ async def matrix_inverse(
 
         result = la.inv(mat)  # type: ignore
 
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Matrix Inverse Result:**\n{_format_matrix(result)}",
@@ -425,11 +426,11 @@ async def matrix_inverse(
                     },
                 }
             ]
-        }
+        )
 
     except ValueError as e:
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Matrix Inverse Error:** {str(e)}",
@@ -441,10 +442,10 @@ async def matrix_inverse(
                     },
                 }
             ]
-        }
+        )
     except Exception as e:
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Unexpected Error:** {str(e)}",
@@ -456,7 +457,7 @@ async def matrix_inverse(
                     },
                 }
             ]
-        }
+        )
 
 
 @matrix_mcp.tool(
@@ -470,7 +471,7 @@ async def matrix_inverse(
 async def matrix_eigenvalues(
     matrix: Annotated[list[list[float]], Field(max_length=MAX_ARRAY_SIZE)],
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> MatrixResult:
     """Calculate the eigenvalues of a square matrix.
 
     Args:
@@ -521,8 +522,8 @@ async def matrix_eigenvalues(
 
         eigenval_str = ", ".join([_format_complex_eigenvalue(val) for val in eigenvalues])
 
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Matrix Eigenvalues:** [{eigenval_str}]",
@@ -535,11 +536,11 @@ async def matrix_eigenvalues(
                     },
                 }
             ]
-        }
+        )
 
     except ValueError as e:
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Matrix Eigenvalues Error:** {str(e)}",
@@ -551,10 +552,10 @@ async def matrix_eigenvalues(
                     },
                 }
             ]
-        }
+        )
     except Exception as e:
-        return {
-            "content": [
+        return MatrixResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Unexpected Error:** {str(e)}",
@@ -566,7 +567,7 @@ async def matrix_eigenvalues(
                     },
                 }
             ]
-        }
+        )
 
 
 __all__ = [

--- a/src/math_mcp/tools/persistence.py
+++ b/src/math_mcp/tools/persistence.py
@@ -3,7 +3,7 @@ Persistence Tools Sub-Server
 FastMCP sub-server for saving and loading calculations from persistent workspace.
 """
 
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastmcp import Context, FastMCP
 from pydantic import Field, SkipValidation
@@ -13,6 +13,7 @@ from math_mcp.eval import (
     _classify_expression_topic,
     validate_variable_name,
 )
+from math_mcp.models import WorkspaceResult
 from math_mcp.settings import (
     MAX_EXPRESSION_LENGTH,
     MAX_VARIABLE_NAME_LENGTH,
@@ -37,7 +38,7 @@ async def save_calculation(
     expression: Annotated[str, Field(max_length=MAX_EXPRESSION_LENGTH)],
     result: float,
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> WorkspaceResult:
     """Save calculation to persistent workspace (survives restarts).
 
     Args:
@@ -67,8 +68,8 @@ async def save_calculation(
 
     result_data = _workspace_manager.save_variable(name, expression, result, metadata)
 
-    return {
-        "content": [
+    return WorkspaceResult(
+        content=[
             {
                 "type": "text",
                 "text": f"**Saved Variable:** {name} = {result}\n**Expression:** {expression}\n**Status:** {'Success' if result_data['success'] else 'Failed'}",
@@ -81,11 +82,11 @@ async def save_calculation(
                 },
             }
         ]
-    }
+    )
 
 
 @persistence_mcp.tool()
-async def load_variable(name: str, ctx: SkipValidation[Context | None] = None) -> dict[str, Any]:
+async def load_variable(name: str, ctx: SkipValidation[Context | None] = None) -> WorkspaceResult:
     """Load previously saved calculation result from workspace.
 
     Args:
@@ -107,8 +108,8 @@ async def load_variable(name: str, ctx: SkipValidation[Context | None] = None) -
         if available:
             error_msg += f"\nAvailable variables: {', '.join(available)}"
 
-        return {
-            "content": [
+        return WorkspaceResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Error:** {error_msg}",
@@ -119,10 +120,10 @@ async def load_variable(name: str, ctx: SkipValidation[Context | None] = None) -
                     },
                 }
             ]
-        }
+        )
 
-    return {
-        "content": [
+    return WorkspaceResult(
+        content=[
             {
                 "type": "text",
                 "text": f"**Loaded Variable:** {name} = {result_data['result']}\n**Expression:** {result_data['expression']}\n**Saved:** {result_data['timestamp']}",
@@ -134,4 +135,4 @@ async def load_variable(name: str, ctx: SkipValidation[Context | None] = None) -
                 },
             }
         ]
-    }
+    )

--- a/src/math_mcp/tools/visualization.py
+++ b/src/math_mcp/tools/visualization.py
@@ -13,6 +13,7 @@ from pydantic import Field, SkipValidation
 
 from math_mcp import visualization
 from math_mcp.eval import _classify_expression_difficulty, evaluate_with_timeout
+from math_mcp.models import VisualizationResult
 from math_mcp.settings import (
     ALLOWED_TRENDS,
     MAX_ARRAY_SIZE,
@@ -50,12 +51,12 @@ def requires_matplotlib(func: Any) -> Any:
     """
 
     @wraps(func)
-    async def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             visualization._setup_matplotlib()
         except ImportError:
-            return {
-                "content": [
+            return VisualizationResult(
+                content=[
                     {
                         "type": "text",
                         "text": (
@@ -71,7 +72,7 @@ def requires_matplotlib(func: Any) -> Any:
                         ),
                     }
                 ]
-            }
+            )
         return await func(*args, **kwargs)
 
     return wrapper
@@ -105,7 +106,7 @@ async def plot_function(
     x_range: tuple[float, float],
     num_points: Annotated[int, Field(ge=2, le=MAX_ARRAY_SIZE)] = 100,
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> VisualizationResult:
     """Generate mathematical function plots (requires matplotlib).
 
     Args:
@@ -169,8 +170,8 @@ async def plot_function(
         # Classify difficulty
         difficulty = _classify_expression_difficulty(expression)
 
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "image",
                     "data": image_base64,
@@ -185,11 +186,11 @@ async def plot_function(
                     ),
                 }
             ]
-        }
+        )
 
     except ValueError as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Plot Error:** {str(e)}\n\nPlease check your expression and x_range values.",
@@ -200,10 +201,10 @@ async def plot_function(
                     ),
                 }
             ]
-        }
+        )
     except Exception as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Unexpected Error:** {str(e)}",
@@ -214,7 +215,7 @@ async def plot_function(
                     ),
                 }
             ]
-        }
+        )
 
 
 @visualization_mcp.tool(
@@ -231,7 +232,7 @@ async def create_histogram(
     bins: int = 20,
     title: Annotated[str, Field(max_length=MAX_STRING_PARAM_LENGTH)] = "Data Distribution",
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> VisualizationResult:
     """Create statistical histograms (requires matplotlib).
 
     Args:
@@ -288,8 +289,8 @@ async def create_histogram(
         if ctx:
             await ctx.report_progress(3, 3, "Complete")
 
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "image",
                     "data": image_base64,
@@ -306,11 +307,11 @@ async def create_histogram(
                     ),
                 }
             ]
-        }
+        )
 
     except ValueError as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Histogram Error:** {str(e)}\n\nPlease check your data and parameters.",
@@ -321,10 +322,10 @@ async def create_histogram(
                     ),
                 }
             ]
-        }
+        )
     except Exception as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Unexpected Error:** {str(e)}",
@@ -335,7 +336,7 @@ async def create_histogram(
                     ),
                 }
             ]
-        }
+        )
 
 
 @visualization_mcp.tool(
@@ -352,7 +353,7 @@ async def plot_line_chart(
     color: Annotated[str | None, Field(max_length=MAX_STRING_PARAM_LENGTH)] = None,
     show_grid: bool = True,
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> VisualizationResult:
     """Create a line chart from data points (requires matplotlib).
 
     Args:
@@ -400,8 +401,8 @@ async def plot_line_chart(
             show_grid=show_grid,
         ).decode("utf-8")
 
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "image",
                     "data": image_base64,
@@ -415,11 +416,11 @@ async def plot_line_chart(
                     ),
                 }
             ]
-        }
+        )
 
     except ValueError as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Line Chart Error:** {str(e)}\n\nPlease check that x_data and y_data have the same length.",
@@ -430,10 +431,10 @@ async def plot_line_chart(
                     ),
                 }
             ]
-        }
+        )
     except Exception as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Unexpected Error:** {str(e)}",
@@ -444,7 +445,7 @@ async def plot_line_chart(
                     ),
                 }
             ]
-        }
+        )
 
 
 @visualization_mcp.tool(
@@ -465,7 +466,7 @@ async def plot_scatter_chart(
     color: Annotated[str | None, Field(max_length=MAX_STRING_PARAM_LENGTH)] = None,
     point_size: int = 50,
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> VisualizationResult:
     """Create a scatter plot from data points (requires matplotlib).
 
     Args:
@@ -513,8 +514,8 @@ async def plot_scatter_chart(
             point_size=point_size,
         ).decode("utf-8")
 
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "image",
                     "data": image_base64,
@@ -528,11 +529,11 @@ async def plot_scatter_chart(
                     ),
                 }
             ]
-        }
+        )
 
     except ValueError as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Scatter Plot Error:** {str(e)}\n\nPlease check that x_data and y_data have the same length.",
@@ -543,10 +544,10 @@ async def plot_scatter_chart(
                     ),
                 }
             ]
-        }
+        )
     except Exception as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Unexpected Error:** {str(e)}",
@@ -557,7 +558,7 @@ async def plot_scatter_chart(
                     ),
                 }
             ]
-        }
+        )
 
 
 @visualization_mcp.tool(
@@ -572,7 +573,7 @@ async def plot_box_plot(
     y_label: Annotated[str, Field(max_length=MAX_STRING_PARAM_LENGTH)] = "Values",
     color: Annotated[str | None, Field(max_length=MAX_STRING_PARAM_LENGTH)] = None,
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> VisualizationResult:
     """Create a box plot for comparing distributions (requires matplotlib).
 
     Args:
@@ -619,8 +620,8 @@ async def plot_box_plot(
             color=color,
         ).decode("utf-8")
 
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "image",
                     "data": image_base64,
@@ -634,11 +635,11 @@ async def plot_box_plot(
                     ),
                 }
             ]
-        }
+        )
 
     except ValueError as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Box Plot Error:** {str(e)}\n\nPlease check your data groups and labels.",
@@ -649,10 +650,10 @@ async def plot_box_plot(
                     ),
                 }
             ]
-        }
+        )
     except Exception as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Unexpected Error:** {str(e)}",
@@ -663,7 +664,7 @@ async def plot_box_plot(
                     ),
                 }
             ]
-        }
+        )
 
 
 @visualization_mcp.tool(
@@ -681,7 +682,7 @@ async def plot_financial_line(
     start_price: float = 100.0,
     color: Annotated[str | None, Field(max_length=MAX_STRING_PARAM_LENGTH)] = None,
     ctx: SkipValidation[Context | None] = None,
-) -> dict[str, Any]:
+) -> VisualizationResult:
     """Generate and plot synthetic financial price data (requires matplotlib).
 
     Creates realistic price movement patterns for educational purposes.
@@ -752,8 +753,8 @@ async def plot_financial_line(
         price_change = ((prices[-1] - prices[0]) / prices[0]) * 100
         volatility = stats.stdev(prices) if len(prices) > 1 else 0
 
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "image",
                     "data": image_base64,
@@ -772,11 +773,11 @@ async def plot_financial_line(
                     ),
                 }
             ]
-        }
+        )
 
     except ValueError as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Financial Chart Error:** {str(e)}\n\nPlease check your parameters (days >= 2, valid trend, positive start_price).",
@@ -787,10 +788,10 @@ async def plot_financial_line(
                     ),
                 }
             ]
-        }
+        )
     except Exception as e:
-        return {
-            "content": [
+        return VisualizationResult(
+            content=[
                 {
                     "type": "text",
                     "text": f"**Unexpected Error:** {str(e)}",
@@ -801,4 +802,4 @@ async def plot_financial_line(
                     ),
                 }
             ]
-        }
+        )

--- a/tests/test_math_operations.py
+++ b/tests/test_math_operations.py
@@ -15,6 +15,7 @@ from math_mcp.eval import (
     evaluate_with_timeout,
     safe_eval_expression,
 )
+from math_mcp.models import CalculationResult
 from math_mcp.resources import get_math_constant, get_workspace
 from math_mcp.settings import (
     MAX_ARRAY_SIZE,
@@ -115,10 +116,9 @@ async def test_calculate_tool():
     ctx = MockContext()
     result = await calculate.raw_function("2 + 3", ctx)
 
-    assert isinstance(result, dict)
-    assert "content" in result
-    assert len(result["content"]) == 1
-    content = result["content"][0]
+    assert isinstance(result, CalculationResult)
+    assert len(result.content) == 1
+    content = result.content[0]
     assert content["type"] == "text"
     assert "2 + 3 = 5.0" in content["text"]
     assert "annotations" in content
@@ -148,9 +148,8 @@ async def test_statistics_tool():
 
     # Test mean
     result = await stats_tool.raw_function([1, 2, 3, 4, 5], "mean", ctx)
-    assert isinstance(result, dict)
-    assert "content" in result
-    content = result["content"][0]
+    assert isinstance(result, CalculationResult)
+    content = result.content[0]
     assert "Mean" in content["text"]
     assert "3.0" in content["text"]
     assert content["annotations"]["topic"] == "statistics"
@@ -159,8 +158,8 @@ async def test_statistics_tool():
 
     # Test median
     result = await stats_tool.raw_function([1, 2, 3, 4, 5], "median", ctx)
-    assert "Median" in result["content"][0]["text"]
-    assert "3.0" in result["content"][0]["text"]
+    assert "Median" in result.content[0]["text"]
+    assert "3.0" in result.content[0]["text"]
 
     # Test empty list
     with pytest.raises(ValueError, match="Cannot calculate statistics on empty list"):
@@ -187,9 +186,8 @@ async def test_compound_interest_tool():
     ctx = MockContext()
     result = await compound_interest(1000.0, 0.05, 5.0, 12, ctx)
 
-    assert isinstance(result, dict)
-    assert "content" in result
-    content = result["content"][0]
+    assert isinstance(result, CalculationResult)
+    content = result.content[0]
     assert "Compound Interest Calculation" in content["text"]
     assert "$1,000.00" in content["text"]
     assert content["annotations"]["topic"] == "finance"
@@ -222,9 +220,8 @@ async def test_convert_units_tool():
     # Test length conversion
     result = await convert_units(100, "cm", "m", "length", ctx)
 
-    assert isinstance(result, dict)
-    assert "content" in result
-    content = result["content"][0]
+    assert isinstance(result, CalculationResult)
+    content = result.content[0]
     assert "100 cm = 1 m" in content["text"]
     assert content["annotations"]["topic"] == "unit_conversion"
     assert content["annotations"]["conversion_type"] == "length"
@@ -233,7 +230,7 @@ async def test_convert_units_tool():
 
     # Test temperature conversion
     result = await convert_units(0, "c", "f", "temperature", ctx)
-    assert "32" in result["content"][0]["text"]
+    assert "32" in result.content[0]["text"]
 
     # Test invalid unit type
     with pytest.raises(ValueError, match="Unknown unit type"):
@@ -312,15 +309,15 @@ async def test_statistical_edge_cases():
 
     # Single value
     result = await stats_tool.raw_function([42.0], "mean", ctx)
-    assert "42.0" in result["content"][0]["text"]
+    assert "42.0" in result.content[0]["text"]
 
     # Standard deviation with single value
     result = await stats_tool.raw_function([42.0], "std_dev", ctx)
-    assert "0" in result["content"][0]["text"]  # Should not raise error
+    assert "0" in result.content[0]["text"]  # Should not raise error
 
     # Variance with single value
     result = await stats_tool.raw_function([42.0], "variance", ctx)
-    assert "0" in result["content"][0]["text"]  # Should not raise error
+    assert "0" in result.content[0]["text"]  # Should not raise error
 
 
 @pytest.mark.asyncio
@@ -340,11 +337,11 @@ async def test_unit_conversion_edge_cases():
 
     # Convert to same unit
     result = await convert_units(100, "m", "m", "length", ctx)
-    assert "100 m = 100 m" in result["content"][0]["text"]
+    assert "100 m = 100 m" in result.content[0]["text"]
 
     # Test case insensitivity
     result = await convert_units(1, "M", "KM", "length", ctx)
-    assert "0.001" in result["content"][0]["text"]
+    assert "0.001" in result.content[0]["text"]
 
 
 # === TIMEOUT TESTS ===
@@ -476,13 +473,13 @@ async def test_expression_length_validation():
     # Create expression like "1+1+1+1..." that's exactly MAX_EXPRESSION_LENGTH - 1 chars
     below_limit_expr = "+".join(["1"] * ((MAX_EXPRESSION_LENGTH) // 2))[: MAX_EXPRESSION_LENGTH - 1]
     result = await calculate.raw_function(below_limit_expr, ctx)
-    assert "content" in result
+    assert result.content is not None
 
     # Valid: at limit (use a valid expression that's exactly at the limit)
     # Create expression like "1+1+1+1..." that's exactly MAX_EXPRESSION_LENGTH chars
     valid_expr = "+".join(["1"] * ((MAX_EXPRESSION_LENGTH + 1) // 2))[:MAX_EXPRESSION_LENGTH]
     result = await calculate.raw_function(valid_expr, ctx)
-    assert "content" in result
+    assert result.content is not None
 
     # Invalid: exceeds limit
     # Create expression like "1+1+1+1..." that exceeds MAX_EXPRESSION_LENGTH
@@ -514,7 +511,7 @@ async def test_array_size_validation():
     # Valid: at limit
     valid_array = [1.0] * MAX_ARRAY_SIZE
     result = await stats_tool.raw_function(valid_array, "mean", ctx)
-    assert "content" in result
+    assert result.content is not None
 
     # Invalid: exceeds limit
     invalid_array = [1.0] * (MAX_ARRAY_SIZE + 1)
@@ -543,7 +540,7 @@ async def test_operation_whitelist_validation():
     # Valid operations
     for op in ["mean", "median", "mode", "std_dev", "variance"]:
         result = await stats_tool.raw_function([1.0, 2.0, 3.0], op, ctx)
-        assert "content" in result
+        assert result.content is not None
 
     # Invalid operation
     with pytest.raises(ValueError, match="Invalid operation"):
@@ -575,12 +572,12 @@ async def test_variable_name_validation():
 
     # Valid: alphanumeric with underscore and hyphen
     result = await save_calculation.raw_function("valid_name-123", "2+2", 4.0, ctx)
-    assert "content" in result
+    assert result.content is not None
 
     # Valid: at limit
     valid_name = "a" * MAX_VARIABLE_NAME_LENGTH
     result = await save_calculation.raw_function(valid_name, "2+2", 4.0, ctx)
-    assert "content" in result
+    assert result.content is not None
 
     # Invalid: exceeds length
     invalid_name = "a" * (MAX_VARIABLE_NAME_LENGTH + 1)
@@ -607,7 +604,7 @@ async def test_string_param_validation():
     valid_title = "a" * MAX_STRING_PARAM_LENGTH
     result = await create_histogram.raw_function([1.0, 2.0, 3.0], 10, valid_title, None)
     # Should return matplotlib not available or success
-    assert "content" in result
+    assert result.content is not None
 
     # Invalid: exceeds limit
     invalid_title = "a" * (MAX_STRING_PARAM_LENGTH + 1)
@@ -625,7 +622,7 @@ async def test_nested_array_validation():
     # Valid: at group limit
     valid_groups = [[1.0, 2.0]] * MAX_GROUPS_COUNT
     result = await plot_box_plot.raw_function(valid_groups, None, "Test", "Y", None, None)
-    assert "content" in result
+    assert result.content is not None
 
     # Invalid: exceeds group count
     invalid_groups = [[1.0, 2.0]] * (MAX_GROUPS_COUNT + 1)
@@ -635,7 +632,7 @@ async def test_nested_array_validation():
     # Valid: at group size limit
     valid_large_group = [[1.0] * MAX_GROUP_SIZE]
     result = await plot_box_plot.raw_function(valid_large_group, None, "Test", "Y", None, None)
-    assert "content" in result
+    assert result.content is not None
 
     # Invalid: exceeds group size
     invalid_large_group = [[1.0] * (MAX_GROUP_SIZE + 1)]
@@ -652,7 +649,7 @@ async def test_days_validation():
     result = await plot_financial_line.raw_function(
         MAX_DAYS_FINANCIAL, "bullish", 100.0, None, None
     )
-    assert "content" in result
+    assert result.content is not None
 
     # Invalid: exceeds limit
     with pytest.raises(
@@ -673,7 +670,7 @@ async def test_trend_whitelist_validation():
     # Valid trends
     for trend in ["bullish", "bearish", "volatile"]:
         result = await plot_financial_line.raw_function(30, trend, 100.0, None, None)
-        assert "content" in result
+        assert result.content is not None
 
     # Invalid trend
     with pytest.raises(ValueError, match="Invalid trend"):
@@ -687,7 +684,7 @@ async def test_num_points_validation():
 
     # Valid: at limit
     result = await plot_function.raw_function("x**2", (-5, 5), MAX_ARRAY_SIZE, None)
-    assert "content" in result
+    assert result.content is not None
 
     # Invalid: exceeds limit
     with pytest.raises(ValueError, match=f"Input should be less than or equal to {MAX_ARRAY_SIZE}"):
@@ -705,7 +702,7 @@ async def test_bins_validation():
 
     # Valid: positive bins
     result = await create_histogram.raw_function([1.0, 2.0, 3.0], 10, "Test", None)
-    assert "content" in result
+    assert result.content is not None
 
     # Invalid: zero bins
     with pytest.raises(ValueError, match="must be at least 1"):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -15,6 +15,7 @@ import pytest
 from fastmcp import FastMCP
 from fastmcp.server.context import Context, set_context
 
+from math_mcp.models import WorkspaceResult
 from math_mcp.persistence.models import WorkspaceData, WorkspaceVariable
 from math_mcp.persistence.storage import (
     ensure_workspace_directory,
@@ -333,9 +334,9 @@ async def test_save_calculation_tool(temp_workspace, mock_context):
         "portfolio_return", "10000 * 1.07^5", 14025.52, mock_context
     )
 
-    assert isinstance(result, dict)
-    assert "content" in result
-    content = result["content"][0]
+    assert isinstance(result, WorkspaceResult)
+    assert len(result.content) == 1
+    content = result.content[0]
     assert content["type"] == "text"
     assert "Saved Variable" in content["text"]
     assert "portfolio_return" in content["text"]
@@ -359,9 +360,8 @@ async def test_load_variable_tool(temp_workspace, mock_context):
     # Then load it using the MCP tool
     result = await load_variable("circle_area", mock_context)
 
-    assert isinstance(result, dict)
-    assert "content" in result
-    content = result["content"][0]
+    assert isinstance(result, WorkspaceResult)
+    content = result.content[0]
     assert content["type"] == "text"
     assert "Loaded Variable" in content["text"]
     assert "circle_area" in content["text"]
@@ -379,8 +379,8 @@ async def test_load_variable_not_found(temp_workspace, mock_context):
     """Test load_variable tool with nonexistent variable."""
     result = await load_variable("nonexistent_var", mock_context)
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, WorkspaceResult)
+    content = result.content[0]
     assert "Error" in content["text"]
     assert "not found" in content["text"]
 
@@ -439,7 +439,7 @@ async def test_save_calculation_validation(temp_workspace, mock_context):
 
     # Valid names should work
     result = await save_calculation.raw_function("valid_name-123", "2 + 2", 4.0, mock_context)
-    assert "Success" in result["content"][0]["text"]
+    assert "Success" in result.content[0]["text"]
 
 
 # === INTEGRATION WITH EXISTING FUNCTIONALITY ===
@@ -472,7 +472,7 @@ async def test_session_id_is_valid_uuid(temp_workspace, mock_context):
     result = await save_calculation.raw_function("test_var", "2 + 2", 4.0, mock_context)
 
     # Extract session_id from annotations
-    annotations = result["content"][0]["annotations"]
+    annotations = result.content[0]["annotations"]
     session_id = annotations.get("session_id")
 
     # Verify it's a valid UUID string
@@ -489,7 +489,7 @@ async def test_session_id_none_when_ctx_is_none(temp_workspace):
     result = await save_calculation.raw_function("test_var", "2 + 2", 4.0, None)
 
     # Extract session_id from annotations
-    annotations = result["content"][0]["annotations"]
+    annotations = result.content[0]["annotations"]
     session_id = annotations.get("session_id")
 
     # Verify it's None when no context
@@ -501,11 +501,11 @@ async def test_session_id_stability_same_context(temp_workspace, mock_context):
     """Test that two save_calculation calls on the same MockContext produce the same session_id."""
     # First save
     result1 = await save_calculation.raw_function("var1", "2 + 2", 4.0, mock_context)
-    session_id_1 = result1["content"][0]["annotations"].get("session_id")
+    session_id_1 = result1.content[0]["annotations"].get("session_id")
 
     # Second save on same context
     result2 = await save_calculation.raw_function("var2", "3 + 3", 6.0, mock_context)
-    session_id_2 = result2["content"][0]["annotations"].get("session_id")
+    session_id_2 = result2.content[0]["annotations"].get("session_id")
 
     # Both should be the same UUID (stable across calls on same context)
     assert session_id_1 is not None

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -9,6 +9,8 @@ suppress unused import warnings as these imports are used for dependency checkin
 
 import pytest
 
+from math_mcp.models import VisualizationResult
+
 # === HELPER FIXTURES ===
 
 
@@ -81,9 +83,8 @@ async def test_plot_function_basic_quadratic(mock_context):
 
     result = await plot_function.raw_function("x**2", (-5.0, 5.0), 50, mock_context)
 
-    assert isinstance(result, dict)
-    assert "content" in result
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
     assert "data" in content
     assert content["mimeType"] == "image/png"
@@ -119,9 +120,8 @@ async def test_plot_function_trigonometric(mock_context):
 
     result = await plot_function.raw_function("sin(x)", (-3.14159, 3.14159), 100, mock_context)
 
-    assert isinstance(result, dict)
-    assert "content" in result
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
     assert content["annotations"]["expression"] == "sin(x)"
     assert content["annotations"]["difficulty"] == "advanced"
@@ -141,8 +141,8 @@ async def test_plot_function_invalid_range(mock_context):
     # x_min >= x_max
     result = await plot_function.raw_function("x**2", (5.0, 5.0), 100, mock_context)
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "text"
     assert "Plot Error" in content["text"]
     assert "minimum must be less than maximum" in content["text"]
@@ -162,8 +162,8 @@ async def test_plot_function_invalid_num_points(mock_context):
     # raw_function bypasses validate_call; the manual guard returns an error dict
     result = await plot_function.raw_function("x**2", (-5.0, 5.0), 1, mock_context)
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "text"
     assert "Plot Error" in content["text"]
     assert "num_points must be at least 2" in content["text"]
@@ -184,8 +184,8 @@ async def test_plot_function_with_domain_error(mock_context):
     result = await plot_function.raw_function("sqrt(x)", (-5.0, 5.0), 50, mock_context)
 
     # Should still succeed but with NaN values for negative x
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
     assert content["annotations"]["expression"] == "sqrt(x)"
 
@@ -203,9 +203,8 @@ async def test_plot_function_without_context():
 
     result = await plot_function.raw_function("x**2", (-5.0, 5.0), 50, None)
 
-    assert isinstance(result, dict)
-    assert "content" in result
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
 
 
@@ -259,9 +258,8 @@ async def test_create_histogram_basic(mock_context):
     data = [1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 5.0]
     result = await create_histogram.raw_function(data, 5, "Test Distribution", mock_context)
 
-    assert isinstance(result, dict)
-    assert "content" in result
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
     assert "data" in content
     assert content["mimeType"] == "image/png"
@@ -300,8 +298,8 @@ async def test_create_histogram_empty_data(mock_context):
 
     result = await create_histogram.raw_function([], 10, "Test", mock_context)
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "text"
     assert "Histogram Error" in content["text"]
     assert "empty data" in content["text"]
@@ -321,8 +319,8 @@ async def test_create_histogram_single_value(mock_context):
 
     result = await create_histogram.raw_function([42.0], 10, "Test", mock_context)
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "text"
     assert "Histogram Error" in content["text"]
     assert "at least 2 data points" in content["text"]
@@ -359,8 +357,8 @@ async def test_create_histogram_large_dataset(mock_context):
     data = [float(i) for i in range(100)]
     result = await create_histogram.raw_function(data, 20, "Large Dataset", mock_context)
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
     assert content["annotations"]["data_points"] == 100
     assert content["annotations"]["bins"] == 20
@@ -380,8 +378,8 @@ async def test_create_histogram_custom_title(mock_context):
     data = [1.0, 2.0, 3.0, 4.0, 5.0]
     result = await create_histogram.raw_function(data, 5, "Custom Title", mock_context)
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
     # Title is embedded in the image, can't directly verify but ensure it doesn't error
 
@@ -400,8 +398,8 @@ async def test_create_histogram_without_context():
     data = [1.0, 2.0, 3.0, 4.0, 5.0]
     result = await create_histogram.raw_function(data, 5, "Test", None)
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
 
 
@@ -421,17 +419,15 @@ async def test_visualization_tools_return_proper_structure(mock_context):
 
     # Test plot_function
     plot_result = await plot_function.raw_function("x**2", (-5.0, 5.0), 50, mock_context)
-    assert "content" in plot_result
-    assert isinstance(plot_result["content"], list)
-    assert len(plot_result["content"]) == 1
-    assert "annotations" in plot_result["content"][0]
+    assert isinstance(plot_result.content, list)
+    assert len(plot_result.content) == 1
+    assert "annotations" in plot_result.content[0]
 
     # Test create_histogram
     histogram_result = await create_histogram.raw_function([1.0, 2.0, 3.0], 5, "Test", mock_context)
-    assert "content" in histogram_result
-    assert isinstance(histogram_result["content"], list)
-    assert len(histogram_result["content"]) == 1
-    assert "annotations" in histogram_result["content"][0]
+    assert isinstance(histogram_result.content, list)
+    assert len(histogram_result.content) == 1
+    assert "annotations" in histogram_result.content[0]
 
 
 @pytest.mark.asyncio
@@ -447,7 +443,7 @@ async def test_visualization_educational_annotations():
 
     # Test plot_function annotations
     plot_result = await plot_function.raw_function("sin(x)", (-3.14, 3.14), 100, None)
-    plot_annotations = plot_result["content"][0]["annotations"]
+    plot_annotations = plot_result.content[0]["annotations"]
     assert "difficulty" in plot_annotations
     assert "topic" in plot_annotations
     assert plot_annotations["topic"] == "visualization"
@@ -457,7 +453,7 @@ async def test_visualization_educational_annotations():
     histogram_result = await create_histogram.raw_function(
         [1.0, 2.0, 3.0, 4.0, 5.0], 5, "Test", None
     )
-    hist_annotations = histogram_result["content"][0]["annotations"]
+    hist_annotations = histogram_result.content[0]["annotations"]
     assert "difficulty" in hist_annotations
     assert hist_annotations["difficulty"] == "intermediate"
     assert "topic" in hist_annotations
@@ -577,8 +573,8 @@ async def test_plot_line_chart_basic(mock_context):
         mock_context,
     )
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
     assert content["annotations"]["chart_type"] == "line"
     assert content["annotations"]["data_points"] == 4
@@ -598,8 +594,8 @@ async def test_plot_scatter_chart_basic(mock_context):
         [1.0, 2.0, 3.0], [2.0, 4.0, 6.0], "Test Scatter", "X", "Y", "purple", 50, mock_context
     )
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
     assert content["annotations"]["chart_type"] == "scatter"
 
@@ -623,8 +619,8 @@ async def test_plot_box_plot_basic(mock_context):
         mock_context,
     )
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
     assert content["annotations"]["chart_type"] == "box_plot"
     assert content["annotations"]["groups"] == 2
@@ -642,8 +638,8 @@ async def test_plot_financial_line_basic(mock_context):
 
     result = await plot_financial_line.raw_function(30, "bullish", 100.0, None, mock_context)
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "image"
     assert content["annotations"]["chart_type"] == "financial_line"
     assert content["annotations"]["days"] == 30
@@ -665,8 +661,8 @@ async def test_plot_line_chart_error_mismatched_length(mock_context):
         [1.0, 2.0], [1.0], "Test", "X", "Y", None, True, mock_context
     )
 
-    assert isinstance(result, dict)
-    content = result["content"][0]
+    assert isinstance(result, VisualizationResult)
+    content = result.content[0]
     assert content["type"] == "text"
     assert "same length" in content["text"]
 
@@ -768,11 +764,10 @@ async def test_requires_matplotlib_import_error(mock_context):
         result = await test_decorated_function(5, mock_context)
 
     # Assert: Returns standardized error dict
-    assert isinstance(result, dict)
-    assert "content" in result
-    assert len(result["content"]) == 1
+    assert isinstance(result, VisualizationResult)
+    assert len(result.content) == 1
 
-    content = result["content"][0]
+    content = result.content[0]
     assert content["type"] == "text"
     assert "Matplotlib not available" in content["text"]
     assert "pip install math-mcp-learning-server[plotting]" in content["text"]
@@ -793,6 +788,7 @@ def test_create_function_plot_basic():
     Act: Call create_function_plot with valid inputs
     Assert: Returns base64-encoded PNG bytes
     """
+    pytest.importorskip("matplotlib")
     from math_mcp.visualization import create_function_plot
 
     # Arrange: Simple linear function data
@@ -815,6 +811,7 @@ def test_create_function_plot_with_nan():
     Act: Call create_function_plot with NaN in y_values
     Assert: Returns valid PNG despite NaN (matplotlib handles gracefully)
     """
+    pytest.importorskip("matplotlib")
     import math
 
     from math_mcp.visualization import create_function_plot
@@ -839,6 +836,7 @@ def test_create_histogram_chart_basic():
     Act: Call create_histogram_chart with valid inputs
     Assert: Returns base64-encoded PNG bytes
     """
+    pytest.importorskip("matplotlib")
     from math_mcp.visualization import create_histogram_chart
 
     # Arrange: Sample data with pre-computed statistics
@@ -864,6 +862,7 @@ def test_create_histogram_chart_bins_exceeds_data():
     Act: Call create_histogram_chart with bins > len(data)
     Assert: Returns valid PNG (matplotlib handles gracefully)
     """
+    pytest.importorskip("matplotlib")
     from math_mcp.visualization import create_histogram_chart
 
     # Arrange: Only 3 data points but 10 bins requested


### PR DESCRIPTION
## Summary

Closes #223.

Adds `src/math_mcp/models.py` with four `BaseModel` subclasses that replace plain `dict[str, Any]` return types across all tool files. MCP clients now receive a typed schema for every tool response.

## Changes

**New file**
- `src/math_mcp/models.py` - `CalculationResult`, `MatrixResult`, `WorkspaceResult`, `VisualizationResult`; each exposes `content: list[dict[str, Any]]` matching the MCP protocol blob shape; educational module docstring explains why typed returns improve client schema generation

**Tool files** (return type annotation + construction updated)
- `tools/calculate.py` - returns `CalculationResult`
- `tools/matrix.py` - returns `MatrixResult`
- `tools/persistence.py` - returns `WorkspaceResult`
- `tools/visualization.py` - returns `VisualizationResult`; `requires_matplotlib` decorator error path updated to return `VisualizationResult` for consistent typing

**Test files** (dict subscript -> attribute access)
- `test_math_operations.py` - `result["key"]` -> `result.key`; `isinstance(result, CalculationResult)` check added
- `test_persistence.py` - same pattern; `isinstance(result, WorkspaceResult)` check added
- `test_visualization.py` - same pattern; `pytest.importorskip("matplotlib")` guards added to four unit tests that call `create_function_plot`/`create_histogram_chart` directly

**Docs**
- `docs/ARCHITECTURE.md` - `models.py` added to module map

## Design decisions

- `content` stays `list[dict[str, Any]]` - MCP protocol blobs are not over-modeled
- No `__getitem__` - pure attribute access only
- Error response dicts (`{"error": ..., "details": ...}`) are left untyped; a follow-up issue will be filed

## Testing

```
uv run pytest          # 90 passed, 32 skipped, 3 pre-existing failures (confirmed against origin/main)
uv run pyright src/    # 6 errors, all pre-existing optional-dependency import errors
uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/  # clean
```