### PR TITLE
docs: restructure README and CONTRIBUTING, fix stale references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 # Contributing to Math MCP Server
 
-Thank you for your interest in contributing to the Math MCP Server! This guide will help you get started.
-
 ## Quick Start
 
 ### Prerequisites
@@ -16,7 +14,7 @@ git clone https://github.com/clouatre-labs/math-mcp-learning-server.git
 cd math-mcp-learning-server
 
 # Install dependencies and activate virtual environment
-uv sync
+uv sync --extra dev --extra plotting
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
 # Verify installation
@@ -130,11 +128,26 @@ See [CI/CD Workflow](https://github.com/clouatre-labs/math-mcp-learning-server/b
 
 ## Code Organization
 
-Single-file architecture for core functionality:
+Modular architecture with composition root and specialized modules:
 ```
-src/math_mcp/server.py    # Core MCP server
-tests/                    # Comprehensive test suite
-ROADMAP.md                # Ideas for later consideration
+src/math_mcp/
+  server.py              # Composition root, middleware, lifespan
+  tools/                 # Tool implementations
+    calculate.py         # Basic math operations
+    matrix.py            # Matrix operations
+    persistence.py       # Workspace persistence
+    visualization.py     # Chart and plot generation
+  persistence/           # State management
+    models.py            # Data models
+    storage.py           # File-based storage
+    workspace.py         # Workspace management
+  resources.py           # MCP resources
+  settings.py            # Configuration
+  eval.py                # Restricted evaluation
+  visualization.py       # Visualization helpers
+  agent_card.py          # A2A agent card
+tests/                   # Comprehensive test suite
+ROADMAP.md               # Ideas for later consideration
 ```
 
 ### Adding New Features
@@ -152,63 +165,27 @@ ROADMAP.md                # Ideas for later consideration
 3. Add appropriate difficulty classification
 4. Test educational metadata
 
-## Contribution Process
+## Contribution Checklist
 
-### Before You Start
 1. Check existing issues and PRs for similar work
 2. Review ROADMAP.md for planned features
 3. Discuss major changes in an issue first
-
-### Making Changes
-1. Fork the repository (for external contributors)
-2. Create feature branch from main
-3. Implement changes following code standards
-4. Add/update tests for your changes
-5. Update documentation as needed
-6. Run quality checks locally
-7. Commit with conventional messages
-
-### Submitting Changes
-1. Push your branch
-2. Create Pull Request with:
-   - Clear title and description
-   - Reference any related issues
-   - Summary of testing performed
-   - Note any breaking changes
-
-### Branch Cleanup
-When closing a PR without merging, please delete your remote branch to keep the repository clean:
-```bash
-git push origin --delete your-branch-name
-```
-Merged PRs automatically delete their branches due to the repository's `delete_branch_on_merge` setting, so no manual cleanup is needed for merged changes.
-
-### PR Review
-- Automated checks must pass
-- Code review by maintainers
-- Discussion of any concerns
-- Approval and merge
+4. Create feature branch from main
+5. Implement changes following code standards
+6. Add/update tests for your changes
+7. Update documentation as needed
+8. Run quality checks locally: `uv run pytest -v && uv run pyright src/ && uv run ruff check src/ tests/`
+9. Commit with conventional messages (GPG-signed, DCO sign-off)
+10. Push your branch and create PR with clear title, description, and testing summary
+11. Delete remote branch if PR is closed without merging (merged PRs auto-delete)
 
 ## What We're Looking For
 
-### High Priority Contributions
-- Additional mathematical domains (linear algebra, calculus)
-- Educational enhancements (better error explanations)
-- Performance improvements
-- Security hardening
-- Test coverage improvements
+**[High Priority]** Additional mathematical domains (linear algebra, calculus); Educational enhancements (better error explanations); Performance improvements; Security hardening; Test coverage improvements
 
-### Medium Priority
-- Documentation improvements
-- Example applications
-- Integration guides
-- Educational use cases
+**[Medium Priority]** Documentation improvements; Example applications; Integration guides; Educational use cases
 
-### Please Avoid
-- Feature bloat that doesn't serve education
-- Complex architectural changes without discussion
-- Breaking changes without clear benefits
-- Dependencies that compromise the minimal philosophy
+**[Avoid]** Feature bloat that doesn't serve education; Complex architectural changes without discussion; Breaking changes without clear benefits; Dependencies that compromise the minimal philosophy
 
 ## Getting Help
 
@@ -219,23 +196,9 @@ Merged PRs automatically delete their branches due to the repository's `delete_b
 
 ## Resources
 
-### MCP Documentation
 - [Model Context Protocol Specification](https://modelcontextprotocol.io/)
-- [FastMCP Documentation](https://github.com/modelcontextprotocol/python-sdk)
-
-### Development Tools
-- [uv Package Manager](https://docs.astral.sh/uv/)
-- [Ruff Linter](https://docs.astral.sh/ruff/)
-- [Pyright Type Checker](https://github.com/microsoft/pyright)
-
-### Mathematical References
-- [Python Math Module](https://docs.python.org/3/library/math.html)
-- [Python Statistics Module](https://docs.python.org/3/library/statistics.html)
+- [FastMCP Documentation](https://gofastmcp.com)
 
 ## Code of Conduct
 
 This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to hugues+mcp-coc@linux.com.
-
----
-
-For questions about this guide, please open an issue or start a discussion.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-Educational MCP server with 17 tools, persistent workspace, and cloud hosting. Built with [FastMCP 3.0](https://github.com/PrefectHQ/fastmcp) and the official [Model Context Protocol Python SDK](https://github.com/modelcontextprotocol/python-sdk).
+Educational MCP server with 17 tools, persistent workspace, and cloud hosting. Built with [FastMCP](https://gofastmcp.com) and the official [Model Context Protocol Python SDK](https://github.com/modelcontextprotocol/python-sdk).
 
 **Available on:**
 - [Official MCP Registry](https://registry.modelcontextprotocol.io/) - `io.github.clouatre-labs/math-mcp-learning-server`
@@ -111,46 +111,7 @@ See [Usage Examples](https://github.com/clouatre-labs/math-mcp-learning-server/b
 
 ## Development
 
-```bash
-# Clone and setup
-git clone https://github.com/clouatre-labs/math-mcp-learning-server.git
-cd math-mcp-learning-server
-uv sync --extra dev --extra plotting
-
-# Test server locally
-uv run fastmcp dev src/math_mcp/server.py
-```
-
-### Testing
-
-```bash
-# Run all tests
-uv run pytest tests/ -v
-
-# Run with coverage
-uv run pytest tests/ --cov=src --cov-report=html --cov-report=term
-
-# Run specific test category
-uv run pytest tests/test_matrix_operations.py -v
-```
-
-**Test Suite:** 122 tests across 6 categories (Agent Card, HTTP Integration, Math, Matrix, Persistence, Visualization); HTTP integration tests run only on release tags.
-
-### Code Quality
-
-```bash
-# Linting
-uv run ruff check
-
-# Formatting
-uv run ruff format --check
-
-# Type checking
-uv run pyright src/
-
-# Security checks
-uv run ruff check --select S
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and contribution guidelines.
 
 ## Security
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ Build capabilities LLMs lack natively: **persistent state**, **visual output**, 
 - **Visualization** (v0.6.0--v0.7.0) -- Function plots, histograms, scatter/line/box/financial charts
 - **Production Hardening** (v0.9.0) -- Rate limiting, input validation, structured logging, CI matrix
 - **Matrix Operations** (v0.10.0) -- Multiply, transpose, determinant, inverse, eigenvalues via NumPy
-- **FastMCP 3.0 Upgrade** (v0.11.0) -- Upgraded from FastMCP 2.x to 3.0; migrated to [PrefectHQ/fastmcp](https://github.com/PrefectHQ/fastmcp); adopted streamable-http transport
+- **FastMCP Upgrade** (v0.11.0) -- Upgraded to FastMCP 3.0; migrated to [PrefectHQ/fastmcp](https://github.com/PrefectHQ/fastmcp); adopted streamable-http transport
 
 ## Upcoming
 
@@ -22,7 +22,7 @@ Build capabilities LLMs lack natively: **persistent state**, **visual output**, 
 - End-to-end workflow tests (calculate, save, load, visualize)
 - Property-based testing with Hypothesis
 
-### FastMCP 3.0 Features
+### FastMCP Features
 
 New capabilities available with the 3.0 upgrade:
 - ResponseLimitingMiddleware for output size control

--- a/docs/SUBMISSION_GUIDE.md
+++ b/docs/SUBMISSION_GUIDE.md
@@ -1,6 +1,6 @@
 # MCP Server Publication Guide
 
-Educational MCP server with 17 tools, persistent workspace, and cloud hosting. Demonstrates FastMCP 2.0 best practices.
+Educational MCP server with 17 tools, persistent workspace, and cloud hosting. Demonstrates FastMCP best practices.
 
 **Links:** [PyPI](https://pypi.org/project/math-mcp-learning-server/) | [GitHub](https://github.com/clouatre-labs/math-mcp-learning-server)
 
@@ -39,7 +39,7 @@ curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.clo
 **Method:** Pull Request to README
 
 ```markdown
-- **[Math MCP Learning](https://github.com/clouatre-labs/math-mcp-learning-server)** - Educational MCP with 12 math/stats tools, persistent workspace, cloud hosting. Demonstrates FastMCP 2.0 best practices.
+- **[Math MCP Learning](https://github.com/clouatre-labs/math-mcp-learning-server)** - Educational MCP with 12 math/stats tools, persistent workspace, cloud hosting. Demonstrates FastMCP best practices.
 ```
 
 ### Awesome MCP Servers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "math-mcp-learning-server"
 version = "0.11.2"
-description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 3.0 best practices for Model Context Protocol development"
+description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.14"
 license = "MIT"

--- a/src/math_mcp/server.py
+++ b/src/math_mcp/server.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Math MCP Server - FastMCP 3.0 Implementation
+Math MCP Server - FastMCP Implementation
 Educational MCP server demonstrating all three MCP pillars: Tools, Resources, and Prompts.
-Uses FastMCP 3.0 patterns with structured output and multi-transport support.
+Uses FastMCP patterns with structured output and multi-transport support.
 """
 
 import logging
@@ -128,7 +128,7 @@ async def build_agent_card() -> AgentCard:
         {
             "protocolVersion": "1.0",
             "name": "Math Learning Server",
-            "description": "Educational MCP server demonstrating FastMCP 3.0 best practices for math operations, visualization, and persistent workspaces.",
+            "description": "Educational MCP server demonstrating FastMCP best practices for math operations, visualization, and persistent workspaces.",
             "version": version,
             "capabilities": {
                 "streaming": False,

--- a/src/math_mcp/tools/visualization.py
+++ b/src/math_mcp/tools/visualization.py
@@ -129,7 +129,7 @@ async def plot_function(
         plot_function("sin(x)", (-3.14, 3.14))
     """
 
-    # FastMCP 2.0 Context logging
+    # FastMCP Context logging
     if ctx:
         await ctx.info(f"Plotting function: {expression} over range {x_range}")
 


### PR DESCRIPTION
## Summary

Restructure README and CONTRIBUTING, fix all stale FastMCP version references, and correct factual errors across 7 files.

## Changes

- Remove FastMCP version numbers from 9 locations (README, server.py, pyproject.toml, SUBMISSION_GUIDE, ROADMAP, visualization.py)
- Drop hard-coded test count from README (was stale at 122)
- Replace single-file architecture description with accurate modular layout in CONTRIBUTING
- Fix `uv sync` command: add `--extra dev --extra plotting`
- Fix FastMCP doc link: gofastmcp.com (was python-sdk)
- Move README Development section to CONTRIBUTING (one-liner link remains in README)
- Trim CONTRIBUTING: collapse Contribution Process into checklist, flatten What We're Looking For, remove filler intro and duplicate closing
- Fix SUBMISSION_GUIDE.md FastMCP 2.0 references (2 locations)

## Testing

- 156 pytest tests passing
- ruff check/format clean
- pyright clean
- gitleaks clean
- No code logic changes (documentation only)

**Net result:** 45 insertions, 121 deletions (-76 lines)

Closes #236