### PR TITLE
chore: release 0.11.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.11.2"
+version = "0.11.3"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ wheels = [
 
 [[package]]
 name = "math-mcp-learning-server"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Release 0.11.3

Patch release covering refactors and documentation improvements since v0.11.2.

### Refactors

- Replace `id(ctx.lifespan_context)` with UUID-based session ID via `ctx.set_state` (#227)
- Remove dead `calculation_history` tracking blocks (#229)
- Replace manual content blobs with Pydantic result models in calculate, matrix, persistence tools (#233)
- Replace manual content blobs with Pydantic result models in visualization tools (#235)
- Add `ctx.report_progress` to statistics tool (#226)

### Documentation

- Update README for clarity and accuracy (#218)
- Add ARCHITECTURE.md with Mermaid diagrams (#224)
- Add ADRs for key architectural decisions (#225)
- Restructure README and CONTRIBUTING, fix stale references (#238)

### Testing

- 156 tests passing
- Pyright: 0 errors
- Ruff: clean