### PR TITLE
feat(server): improve instructions, add tools catalog resource, add constant completions

### DIFF
--- a/src/math_mcp/resources.py
+++ b/src/math_mcp/resources.py
@@ -120,6 +120,119 @@ async def get_workspace(ctx: Context) -> str:
     return _workspace_manager.get_workspace_summary()
 
 
+@resources_mcp.resource("math://catalog/tools")
+async def list_tools_catalog(ctx: Context) -> str:
+    """Catalog of all available tools with category, description, and example."""
+    await ctx.info("Accessing tools catalog")
+    catalog = [
+        {
+            "name": "calculate",
+            "category": "calculate",
+            "readOnly": True,
+            "example": "calculate('2 + 2')",
+        },
+        {
+            "name": "statistics",
+            "category": "calculate",
+            "readOnly": True,
+            "example": "statistics([1,2,3,4,5], 'mean')",
+        },
+        {
+            "name": "compound_interest",
+            "category": "calculate",
+            "readOnly": True,
+            "example": "compound_interest(1000, 0.05, 10)",
+        },
+        {
+            "name": "convert_units",
+            "category": "calculate",
+            "readOnly": True,
+            "example": "convert_units(100, 'cm', 'm', 'length')",
+        },
+        {
+            "name": "matrix_multiply",
+            "category": "matrix",
+            "readOnly": True,
+            "example": "matrix_multiply([[1,2],[3,4]], [[5,6],[7,8]])",
+        },
+        {
+            "name": "matrix_determinant",
+            "category": "matrix",
+            "readOnly": True,
+            "example": "matrix_determinant([[1,2],[3,4]])",
+        },
+        {
+            "name": "matrix_inverse",
+            "category": "matrix",
+            "readOnly": True,
+            "example": "matrix_inverse([[1,2],[3,4]])",
+        },
+        {
+            "name": "matrix_transpose",
+            "category": "matrix",
+            "readOnly": True,
+            "example": "matrix_transpose([[1,2,3],[4,5,6]])",
+        },
+        {
+            "name": "matrix_eigenvalues",
+            "category": "matrix",
+            "readOnly": True,
+            "example": "matrix_eigenvalues([[4,2],[1,3]])",
+        },
+        {
+            "name": "plot_function",
+            "category": "visualize",
+            "readOnly": True,
+            "example": "plot_function('sin(x)', (-3.14, 3.14))",
+        },
+        {
+            "name": "plot_histogram",
+            "category": "visualize",
+            "readOnly": True,
+            "example": "plot_histogram([1,2,2,3,3,3])",
+        },
+        {
+            "name": "plot_scatter",
+            "category": "visualize",
+            "readOnly": True,
+            "example": "plot_scatter([1,2,3], [4,5,6])",
+        },
+        {
+            "name": "plot_bar_chart",
+            "category": "visualize",
+            "readOnly": True,
+            "example": "plot_bar_chart(['A','B'], [10,20])",
+        },
+        {
+            "name": "plot_heatmap",
+            "category": "visualize",
+            "readOnly": True,
+            "example": "plot_heatmap([[1,2],[3,4]])",
+        },
+        {
+            "name": "create_animated_plot",
+            "category": "visualize",
+            "readOnly": True,
+            "example": "create_animated_plot('sin(x*t)', (-3.14,3.14))",
+        },
+        {
+            "name": "save_calculation",
+            "category": "workspace",
+            "readOnly": False,
+            "example": "save_calculation('result', 42.0, 'my_calc')",
+        },
+        {
+            "name": "load_variable",
+            "category": "workspace",
+            "readOnly": True,
+            "example": "load_variable('result')",
+        },
+    ]
+    import json
+
+    return json.dumps({"tools": catalog, "count": len(catalog)}, indent=2)
+
+
 @resources_mcp.prompt()
 def math_tutor(topic: str, level: str = "intermediate", include_examples: bool = True) -> str:
     """Generate a math tutoring prompt for explaining concepts.

--- a/src/math_mcp/server.py
+++ b/src/math_mcp/server.py
@@ -16,6 +16,7 @@ from fastmcp.server.middleware.rate_limiting import (
     RateLimitError,
     SlidingWindowRateLimitingMiddleware,
 )
+from mcp.types import Completion, ResourceTemplateReference
 from starlette.responses import JSONResponse
 
 from math_mcp.agent_card import AgentCard, AgentSkill
@@ -27,7 +28,20 @@ from math_mcp.tools import calculate_mcp, matrix_mcp, persistence_mcp, visualiza
 
 mcp = FastMCP(
     name="Math Learning Server",
-    instructions="A comprehensive math server demonstrating MCP fundamentals with tools, resources, and prompts for educational purposes.",
+    instructions=(
+        "Math Learning Server - use these tools for mathematical computation:\n\n"
+        "CALCULATE: Use `calculate` for arithmetic/algebra, `statistics` for lists, "
+        "`compound_interest` for finance (rate as decimal: 0.05 = 5%), "
+        "`convert_units` for unit conversion (length/weight/temperature).\n\n"
+        "MATRIX: Use `matrix_multiply`, `matrix_determinant`, `matrix_inverse`, "
+        "`matrix_transpose`, `matrix_eigenvalues` for linear algebra.\n\n"
+        "VISUALIZE: Use `plot_function`, `plot_histogram`, `plot_scatter`, "
+        "`plot_bar_chart`, `plot_heatmap`, `create_animated_plot` for charts.\n\n"
+        "WORKSPACE: Use `save_calculation` to persist results, `load_variable` to retrieve. "
+        "Results survive server restarts. View all via math://workspace resource.\n\n"
+        "RESOURCES: math://functions (syntax reference), math://constants/{name} "
+        "(pi/e/golden_ratio/euler_gamma/sqrt2/sqrt3), math://catalog/tools (tool index)."
+    ),
 )
 
 # Mount sub-server tools using FastMCP composition pattern
@@ -56,6 +70,28 @@ if RATE_LIMIT_PER_MINUTE > 0:
         SlidingWindowRateLimitingMiddleware(max_requests=RATE_LIMIT_PER_MINUTE, window_minutes=1)
     )
     logging.info(f"Rate limiting enabled: {RATE_LIMIT_PER_MINUTE} requests/minute")
+
+
+# === ARGUMENT COMPLETIONS ===
+
+# Constants list must match resources.py get_math_constant keys
+_CONSTANTS = ["pi", "e", "golden_ratio", "euler_gamma", "sqrt2", "sqrt3"]
+
+
+@mcp._mcp_server.completion()
+async def handle_completion(
+    ref: object,
+    argument: object,
+    context: object = None,
+) -> Completion | None:
+    """Provide tab-completions for math://constants/{constant} resource template."""
+    if not isinstance(ref, ResourceTemplateReference):
+        return None
+    if ref.uri != "math://constants/{constant}":
+        return None
+    prefix = getattr(argument, "value", "") or ""
+    matches = [c for c in _CONSTANTS if c.startswith(prefix)]
+    return Completion(values=matches)
 
 
 # === AGENT CARD ENDPOINT ===


### PR DESCRIPTION
## Summary

Three ergonomics improvements: actionable server instructions, a tools catalog resource, and MCP argument completions for the constants resource template. Depends on #258 (Shard A) being merged first.

## Changes

- `src/math_mcp/server.py`: Replace single-line instructions with multi-line tool-selection guide (CALCULATE / MATRIX / VISUALIZE / WORKSPACE / RESOURCES sections); register `handle_completion` via `mcp._mcp_server.completion()` scoped to `math://constants/{constant}` resource template
- `src/math_mcp/resources.py`: Add `math://catalog/tools` resource returning hardcoded JSON index of all 17 tools with category, readOnly flag, and example call

## Issues closed

Closes #255, #256, #257

## Test plan

- [x] 91 tests pass (8 pre-existing failures confirmed unrelated: 4 matplotlib import errors, 4 validation failures)
- [x] Linter clean (`uv run ruff check`)
- [x] Formatter clean (`uv run ruff format --check`)
- [x] Type check clean (`uv run pyright src/`)
- [x] Server import clean (`from math_mcp.server import mcp`)
- [x] Security scan clean

## Design notes

- Completion handler scoped to resource templates only (tool argument completions are out-of-spec per MCP)
- Catalog resource uses hardcoded JSON to avoid circular import between `resources_mcp` sub-server and the main `mcp` instance
- `Completion` and `ResourceTemplateReference` imported at module level for correct pyright typing

## Notes

This branch is based on `feat/wave3-shard-a-corrections` (#258). Once that PR merges, this branch will rebase cleanly onto `main`.