### PR TITLE
docs: update badges -- add CI, switch license to Apache-2.0, add MCP protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <!-- mcp-name: io.github.clouatre-labs/math-mcp-learning-server -->
 # Math MCP Learning Server
 
+[![CI](https://img.shields.io/github/actions/workflow/status/clouatre-labs/math-mcp-learning-server/ci.yml?branch=main)](https://github.com/clouatre-labs/math-mcp-learning-server/actions/workflows/ci.yml)
 [![PyPI version](https://badge.fury.io/py/math-mcp-learning-server.svg)](https://pypi.org/project/math-mcp-learning-server/)
 [![Python](https://img.shields.io/pypi/pyversions/math-mcp-learning-server)](https://pypi.org/project/math-mcp-learning-server/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![MCP](https://img.shields.io/badge/protocol-MCP-purple.svg)](https://modelcontextprotocol.io)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 Educational MCP server with 17 tools, persistent workspace, and cloud hosting. Built with [FastMCP](https://gofastmcp.com) and the official [Model Context Protocol Python SDK](https://github.com/modelcontextprotocol/python-sdk).


### PR DESCRIPTION
## Summary

Full badge block refresh aligned to the code-analyze-mcp reference pattern.

## Changes

- Added CI status badge (points to \`ci.yml\` workflow on \`main\`)
- Replaced MIT license badge with Apache-2.0 badge pointing to local \`LICENSE\` file
- Added MCP protocol badge (matching code-analyze-mcp)
- Reordered badges: CI, PyPI, Python, License, MCP, Ruff

No content sections were changed (tool count, links, descriptions all unchanged).

## Badge set before / after

Before (4 badges): PyPI, Python, License (MIT), Ruff

After (6 badges): CI, PyPI, Python, License (Apache-2.0), MCP, Ruff

## Test plan

- [ ] Badges render correctly in GitHub preview
- [ ] CI badge reflects workflow status
- [ ] No content regressions