### PR TITLE
ci: add top-level permissions block to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,15 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   verify-tag-signature:
     name: Verify GPG tag signature
     runs-on: ubuntu-24.04
     if: github.event_name == 'push'
+    permissions:
+      contents: read
     outputs:
       tag: ${{ steps.extract.outputs.tag }}
     steps:


### PR DESCRIPTION
Add explicit top-level permissions block to lock down token scope.

## Changes
- `.github/workflows/release.yml`: add `permissions: {}` at workflow level
- `.github/workflows/release.yml`: add `contents: read` to `verify-tag-signature` job

## Motivation
Missing top-level permissions block means workflow inherits org write default. Prerequisite for issue #17 (github-token-read-only org default).