### PR TITLE
ci: add CI Result aggregate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,18 @@ jobs:
     
     - name: Run HTTP integration tests
       run: uv run pytest tests/test_http_integration.py -v
+
+  ci-result:
+    name: CI Result
+    runs-on: ubuntu-24.04
+    if: always()
+    needs: [lint, security, test]
+    permissions: {}
+    steps:
+      - name: Verify all jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "::error::One or more CI jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped."


### PR DESCRIPTION
Add a terminal CI Result job that aggregates lint, security, and test for required-check simplicity.

## Changes
- Add `ci-result` aggregate job depending on `lint`, `security`, `test`
- `test-http-integration` is tag-only and excluded from the aggregate

## Motivation
A single required check is simpler to maintain in branch rulesets than enumerating individual jobs.