### PR TITLE
fix(ci): correct zizmor min-severity value (error -> high)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           advanced-security: false
           annotations: true
-          min-severity: error
+          min-severity: high
 
   ci-result:
     name: CI Result


### PR DESCRIPTION
## Summary

Fixes CI broken by #269 (`chore(ci): add zizmor SHA-pinning enforcement`).

`min-severity: error` is not a valid zizmor value — valid values are `informational`, `low`, `medium`, `high`. Corrected to `high`.

## Changes

- `.github/workflows/ci.yml` — `min-severity: error` → `high`

## Test plan

- [ ] zizmor job passes
- [ ] No other CI jobs affected