### PR TITLE
ci: skip code jobs on docs-only changes via paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,8 @@ name: CI
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
-      - 'docs/**'
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
-      - 'docs/**'
 
 env:
   PYTHON_VERSION: "3.14"
@@ -25,19 +17,40 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/**'
+
   lint:
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-    
+
     - name: Ruff check
       uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
       with:
         version: '>=0.14.0,<0.15.0'
         args: 'check'
-    
+
     - name: Ruff format
       uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
       with:
@@ -45,13 +58,14 @@ jobs:
         args: 'format --check'
 
   security:
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
-    
+
     - name: Secret scanning
       uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
       env:
@@ -60,21 +74,22 @@ jobs:
 
   test:
     # Single-version CI: version pinned in env.PYTHON_VERSION above
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-    
+
     - name: Set up uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         enable-cache: true
         python-version: ${{ env.PYTHON_VERSION }}
-    
+
     - name: Install dependencies
       run: uv sync --all-extras
-    
+
     - name: Run tests with coverage
       run: uv run pytest tests/ -v --cov=math_mcp --cov-report=term-missing --cov-fail-under=80
 
@@ -84,21 +99,23 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-    
+
     - name: Set up uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         enable-cache: true
         python-version: ${{ env.PYTHON_VERSION }}
-    
+
     - name: Install dependencies
       run: uv sync --all-extras
-    
+
     - name: Run HTTP integration tests
       run: uv run pytest tests/test_http_integration.py -v
 
   zizmor:
     name: zizmor
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -114,7 +131,7 @@ jobs:
     name: CI Result
     runs-on: ubuntu-24.04
     if: always()
-    needs: [lint, security, test, zizmor]
+    needs: [changes, lint, security, test, zizmor]
     permissions: {}
     steps:
       - name: Verify all jobs passed or were skipped


### PR DESCRIPTION
## Summary

Adds a \`changes\` job using \`dorny/paths-filter\` to detect whether code files changed. All substantive jobs (\`lint\`, \`security\`, \`test\`, \`zizmor\`) skip on docs-only PRs; \`CI Result\` reports success in that case.

Also removes \`paths-ignore\` from the workflow triggers -- path filtering at the trigger level prevents \`CI Result\` from running at all, leaving the required status check in a pending state.

## Changes

- `.github/workflows/ci.yml`

## Test plan

- [ ] Docs-only PR: all code jobs skip, CI Result passes
- [ ] Code PR: all jobs run as before