### PR TITLE
fix: update pyproject.toml description to concise canonical form

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "math-mcp-learning-server"
 version = "0.11.4"
-description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP best practices for Model Context Protocol development"
+description = "Educational MCP server for math operations, statistics, visualization, and persistent workspaces. Built with FastMCP."
 readme = "README.md"
 requires-python = ">=3.14"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Updates the package description to a concise, accurate form without version-pinning FastMCP.

## Changes

- `pyproject.toml`: Replace long-form description with: _"Educational MCP server for math operations, statistics, visualization, and persistent workspaces. Built with FastMCP."_

## Motivation

The previous description was verbose and referenced FastMCP best practices framing. The new description is canonical and avoids surfacing a version number (e.g. FastMCP 2.0) on third-party registries like Fronteir AI.