### PR TITLE
chore: bump version to 0.11.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.11.4"
+version = "0.11.5"
 description = "Educational MCP server for math operations, statistics, visualization, and persistent workspaces. Built with FastMCP."
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
Bumps version from 0.11.4 to 0.11.5 ahead of the release tag.