### PR TITLE
feat(prompts): enrich @mcp.prompt decorators with title, tags, and description

### DIFF
--- a/src/math_mcp/resources.py
+++ b/src/math_mcp/resources.py
@@ -242,7 +242,11 @@ async def list_tools_catalog(ctx: Context) -> str:
     return json.dumps({"tools": catalog, "count": len(catalog)}, indent=2)
 
 
-@resources_mcp.prompt()
+@resources_mcp.prompt(
+    title="Math Tutor",
+    tags={"education", "tutoring", "math", "explanation"},
+    description="Generate a structured math tutoring prompt for a mathematical concept at a chosen difficulty level, optionally including step-by-step worked examples.",
+)
 def math_tutor(topic: str, level: str = "intermediate", include_examples: bool = True) -> str:
     """Generate a math tutoring prompt for explaining concepts.
 
@@ -269,7 +273,11 @@ Make your explanation engaging and accessible for a {level} learner. Use analogi
     return prompt
 
 
-@resources_mcp.prompt()
+@resources_mcp.prompt(
+    title="Formula Explainer",
+    tags={"education", "formulas", "math", "explanation"},
+    description="Generate a comprehensive prompt for explaining a mathematical formula: variable definitions, contextual background, step-by-step breakdown, example calculation, real-world applications, and common mistakes.",
+)
 def formula_explainer(formula: str, context: str = "general mathematics") -> str:
     """Generate a prompt for explaining mathematical formulas in detail.
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -103,3 +103,23 @@ async def test_enum_like_params_have_examples() -> None:
         f"Enum-like params missing examples or enum ({len(violations)} total):\n"
         + "\n".join(f"  - {v}" for v in sorted(violations))
     )
+
+
+async def _get_prompts() -> list:
+    async with Client(mcp) as client:
+        return await client.list_prompts()
+
+
+@pytest.mark.asyncio
+async def test_all_prompts_have_titles_and_descriptions() -> None:
+    """Every prompt must have a non-empty title and a non-empty description string."""
+    prompts = await _get_prompts()
+    violations: list[str] = []
+    for p in prompts:
+        title = (getattr(p, "title", None) or "").strip()
+        description = (p.description or "").strip()
+        if not title:
+            violations.append(f"{p.name}: missing title")
+        if not description:
+            violations.append(f"{p.name}: missing description")
+    assert violations == [], f"Prompt annotation violations: {violations}"


### PR DESCRIPTION
## Summary

Add \`title=\`, \`tags=\`, and \`description=\` to the two bare \`@resources_mcp.prompt()\` decorators in \`resources.py\`, aligned with [\`MCP-BEST-PRACTICES.md\`](https://github.com/clouatre-labs/code-analyze-mcp/blob/main/docs/MCP-BEST-PRACTICES.md) sections 3.3 (tool annotations) and 4.1.1 (description scope).

- \`title=\` provides a human-readable display name for MCP client confirmation UI (section 3.3)
- \`tags=\` enables categorization and filtering in MCP clients (\`set[str]\`)
- \`description=\` provides a concise MCP wire-protocol summary independent of the Python docstring; answers "what does this prompt do and when should I use it?" without duplicating parameter detail (section 4.1.1)

Existing docstrings are preserved unchanged as Python dev documentation.

## Changes

- \`src/math_mcp/resources.py\`: enrich \`math_tutor\` and \`formula_explainer\` prompt decorators
- \`tests/test_annotations.py\`: add \`test_all_prompts_have_titles_and_descriptions()\` mirroring the existing \`list_tools()\` assertion pattern

## Test plan

- [x] \`uv run pytest tests/test_annotations.py -v\` -- 5 passed (4 existing + 1 new)
- [x] New test verified to catch regressions (fails when \`title=\` is removed)
- [x] \`uv run ruff check src/ tests/\` -- clean
- [x] \`uv run ruff format --check src/ tests/\` -- clean
- [x] No new dependencies added
- [x] No functional changes to prompt return values
- [x] Security scan clean (gitleaks: 0 leaks)