### PR TITLE
ci: add pip-audit CVE scanning and commitlint enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
+    - name: Set up uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+    - name: Scan dependencies for CVEs
+      run: uv tool run pip-audit
+
   test:
     # Single-version CI: version pinned in env.PYTHON_VERSION above
     needs: changes
@@ -127,11 +133,26 @@ jobs:
           annotations: true
           min-severity: high
 
+  commitlint:
+    name: commitlint
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Lint commit messages
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
+
   ci-result:
     name: CI Result
     runs-on: ubuntu-24.04
     if: always()
-    needs: [lint, security, test, zizmor]
+    needs: [lint, security, test, zizmor, commitlint]
     permissions: {}
     steps:
       - name: Verify all jobs passed or were skipped


### PR DESCRIPTION
## Summary

Adds two CI jobs required for OpenSSF Best Practices Passing level.

- **pip-audit**: Added as a step inside the existing \`security\` job. Scans Python dependencies for known CVEs via \`uv tool run pip-audit\` (no new pyproject.toml dependencies). Runs on every PR and push.
- **commitlint**: New standalone job (PR-only, \`if: github.event_name == 'pull_request'\`) enforcing conventional commits using \`wagoid/commitlint-github-action\` SHA-pinned at the same commit as \`code-analyze-mcp\`. Skipped on push to main; the \`ci-result\` gate correctly handles \`skipped\` as non-failure.

Both jobs added to the \`ci-result\` gate.

## Changes

- \`.github/workflows/ci.yml\`: +setup-uv step + pip-audit step in security job, +commitlint job, +commitlint in ci-result needs

## Test plan

- [x] YAML valid
- [x] 171 tests pass, 0 failed
- [x] Lint clean
- [x] All action SHAs pinned with tag comments

Depends on #296 (clean test baseline).
Closes #288