### PR TITLE
ci: add REUSE compliance (SPDX license headers + reuse workflow)

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,50 @@
+name: REUSE Compliance
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.py"
+      - "**/*.yml"
+      - "**/*.yaml"
+      - "**/*.toml"
+      - "**/*.json"
+      - "**/*.md"
+      - "uv.lock"
+      - "LICENSES/**"
+      - "REUSE.toml"
+      - ".github/workflows/reuse.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**/*.py"
+      - "**/*.yml"
+      - "**/*.yaml"
+      - "**/*.toml"
+      - "**/*.json"
+      - "**/*.md"
+      - "uv.lock"
+      - "LICENSES/**"
+      - "REUSE.toml"
+      - ".github/workflows/reuse.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  reuse:
+    name: reuse
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check REUSE compliance
+        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,187 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but not
+      limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner, any work of
+      authorship, including the original version of the Work and any
+      modifications or additions to that Work or Derivative Works of the Work.
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent contributions
+      Licensable by such Contributor that are necessarily infringed by
+      their Contribution(s) alone or by the combination of their
+      Contribution(s) with the Work to which such Contribution(s) was
+      submitted. If You institute patent litigation against any entity
+      (including a cross-claim or counterclaim in a lawsuit) alleging that
+      the Work or any such Contribution(s) constitutes direct or
+      contributory patent infringement, then any patent licenses granted to
+      You under this License for that Work shall terminate as of the date
+      such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, and to permit persons to whom the Contribution is
+      furnished to do so.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (even if such Contributor has been advised of the possibility
+      of such damages).
+
+   9. Accepting Warranty or Liability. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may offer such conditions only on
+      Your own behalf and on Your behalf of all other Contributors,
+      and only if You agree to indemnify, defend, and hold each
+      Contributor harmless for any liability incurred by, or claims
+      asserted against, such Contributor by reason of your accepting
+      any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the format in question. Please also consider
+      attaching a "NOTICE" file with your project as described in
+      Appendix of the Apache License. You are not required to include
+      the copyright owner in these fields.
+
+   Copyright 2025 Hugues Clouatre
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,208 @@
+version = 1
+SPDX-PackageName = "math-mcp-learning-server"
+SPDX-PackageSupplier = "math-mcp-learning-server Contributors"
+SPDX-PackageDownloadLocation = "https://github.com/clouatre-labs/math-mcp-learning-server"
+
+[[annotations]]
+path = "src/**/**.py"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "tests/**/**.py"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".github/**/**.yml"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".github/**/**.yaml"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "**.toml"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "**.lock"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "**.json"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "**.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "docs/**/**.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "docs/**/**.png"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "docs/**/**.svg"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "LICENSE"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "SECURITY.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "CONTRIBUTING.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "CHANGELOG.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "README.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "CITATION.cff"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".zenodo.json"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".github/CODEOWNERS"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".github/**/**.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "scripts/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "Makefile"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".gitignore"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".editorconfig"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "**.sh"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".mailmap"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "tests/conftest.py"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "tests/test_agent_card.py"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "tests/test_annotations.py"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "tests/test_http_integration.py"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "tests/test_math_operations.py"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "tests/test_matrix_operations.py"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "tests/test_persistence.py"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "tests/test_visualization.py"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
+SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
## Summary

Adds REUSE compliance using the org-standard bulk annotation approach (same as \`aptu\` and \`code-analyze-mcp\`).

Satisfies OpenSSF Gold criteria \`copyright_per_file\` and \`license_per_file\` without editing any existing source files.

## Changes

- **\`REUSE.toml\`** (new): Bulk annotation with glob patterns covering all 63 repository files. Apache-2.0 + \`2026 math-mcp-learning-server Contributors\` copyright. REUSE spec v1.
- **\`LICENSES/Apache-2.0.txt\`** (new): Full Apache-2.0 license text (copy of root \`LICENSE\`).
- **\`.github/workflows/reuse.yml\`** (new): REUSE compliance workflow using SHA-pinned \`fsfe/reuse-action\` v6 (\`676e2d56\`). Triggers on \`.py\`, \`.yml\`, \`.toml\`, \`.json\`, \`.md\`, \`uv.lock\`, \`LICENSES/\`, \`REUSE.toml\` changes.
- **\`.github/workflows/ci.yml\`**: Add \`reuse\` to \`ci-result\` gate needs array.

## Test plan

- [x] \`uvx reuse lint\` exits 0: 63/63 files compliant
- [x] YAML valid (ci.yml + reuse.yml)
- [x] 171 tests pass, 0 failed
- [x] Lint clean
- [x] No existing source files modified

Depends on #296 (clean test baseline).
Closes #292