### PR TITLE
chore: add CODEOWNERS and enforce branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# All changes require review from the project maintainer
+* @clouatre
+
+# Workflow changes require maintainer review
+.github/workflows/ @clouatre


### PR DESCRIPTION
## Summary

Adds \`.github/CODEOWNERS\` requiring maintainer review (\`@clouatre\`) on all changes, satisfying the OpenSSF Best Practices code ownership criterion.

## Changes

- \`.github/CODEOWNERS\`: new file, 5 lines

## Branch protection (applied post-merge)

After this PR merges and after PR #297 (pip-audit+commitlint) is merged so the \`CI Result\` status check exists, apply branch protection via:

\`\`\`bash
gh api repos/clouatre-labs/math-mcp-learning-server/branches/main/protection   -X PUT   -f required_status_checks[strict]=false   -f 'required_status_checks[contexts][]=CI Result'   -f enforce_admins=false   -f required_pull_request_reviews[required_approving_review_count]=1   -f required_pull_request_reviews[require_code_owner_reviews]=true   -f required_pull_request_reviews[dismiss_stale_reviews]=false   -F restrictions=null   -F allow_force_pushes=false   -F allow_deletions=false

gh api repos/clouatre-labs/math-mcp-learning-server/branches/main/protection/required_signatures   -X POST
\`\`\`

## Test plan

- [x] CODEOWNERS file exists with correct syntax
- [x] Single file change, no src/ modifications
- [x] Commit GPG-signed with DCO sign-off

Depends on #297 (CI jobs must exist before they can be required status checks).
Closes #289