### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,42 @@
+name: Scorecard
+
+on:
+  schedule:
+    - cron: "30 1 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Scorecard analysis
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      security-events: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload results to Security tab
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5


### PR DESCRIPTION
## Summary

Adds weekly OpenSSF Scorecard analysis, satisfying a Silver-level criterion and producing a scorecard.dev badge.

The workflow follows the org-standard \`aptu\` pattern with \`publish_results: true\` so results appear on the public scorecard.dev dashboard.

## Changes

- \`.github/workflows/scorecard.yml\` (new): 42 lines
  - SHA-pinned \`ossf/scorecard-action@4eaacf05\` (v2.4.3)
  - SHA-pinned \`actions/checkout@de0fac2e\` (v6) with \`persist-credentials: false\`
  - SHA-pinned \`actions/upload-artifact\` for SARIF file
  - Schedule: Mondays 01:30 UTC + \`workflow_dispatch\`
  - Permissions: \`id-token: write\`, \`security-events: write\`, \`contents: read\`
  - \`publish_results: true\` (public repo)
  - SARIF upload to GitHub Security tab (5-day retention)
  - Not in \`ci-result\` gate (separate cadence)

## Test plan

- [x] YAML valid
- [x] 171 tests pass
- [x] All actions SHA-pinned with tag comments

Depends on #300 (branch protection should be in place before Scorecard scores it).
Closes #290