### PR TITLE
docs: document code review standards and security review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,20 @@ HTTP integration tests run only on release tags (see [Maintainer Guide](https://
 
 See [CI/CD Workflow](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/.github/workflows/ci.yml) for implementation details.
 
+## Code Review
+
+All pull requests require at least one approving review before merge. This is enforced by
+branch protection on `main`.
+
+Reviewer checklist:
+
+- **Correctness**: logic is sound, edge cases handled, no regressions
+- **Test coverage**: new behavior has a test; no untested code paths added
+- **Security**: no use of `eval()` outside `src/math_mcp/eval.py`; all inputs validated
+  with Pydantic; no secrets or credentials in code
+- **Conventions**: conventional commits, GPG + DCO sign-off, `ruff` and `pyright` clean
+- **Documentation**: public functions have docstrings; architectural changes have an ADR
+
 ## Code Standards
 
 ### Python Style

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -97,6 +97,21 @@ This project implements several security measures:
 - Minimal dependency footprint (core uses stdlib only)
 - Security scanning in CI/CD pipeline
 
+## Security Review
+
+A security review of this project was conducted in March 2026.
+
+**Scope:**
+- `src/math_mcp/eval.py`: restricted `eval()` implementation -- character whitelist,
+  dangerous-pattern blocklist, globals locked to `{abs, math}` only
+- Input validation: Pydantic `validate_call` on all tool inputs
+- Workspace path restriction in `src/math_mcp/persistence/`
+
+**Findings:** No critical issues identified.
+
+**Next review:** Within 12 months or upon any change to `eval.py` or the input
+validation layer.
+
 ## Scope
 
 ### In Scope


### PR DESCRIPTION
## Summary

Adds two sections required for OpenSSF Gold criteria `code_review_standards` and `security_review`.

## Changes

### CONTRIBUTING.md (+14 lines)
New **Code Review** section inserted after the CI/CD Workflow section:
- States that all PRs require one approving review (enforced by branch protection from #300)
- Reviewer checklist: correctness, test coverage, security (eval sandbox + Pydantic), conventions, documentation

### SECURITY.md (+15 lines)
New **Security Review** section inserted after Security Best Practices:
- March 2026 review scope: `eval()` sandbox (character whitelist, dangerous-pattern blocklist, globals locked to `{abs, math}`), Pydantic `validate_call` on all inputs, workspace path restriction
- Findings: no critical issues
- Next review cadence: 12 months or on any change to `eval.py`

No existing content modified. No duplication between the two files.

## Test plan

- [x] Code Review section present in CONTRIBUTING.md with reviewer checklist
- [x] Security Review section present in SECURITY.md with scope, date, findings
- [x] No duplication between files
- [x] Doc-only change; 2 files, 29 lines added

Depends on #300 (branch protection is the enforcement mechanism referenced in Code Review section).
Closes #293
