### PR TITLE
chore: remove .mailmap and its REUSE annotation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,0 @@
-# Consolidate all Hugues Clouâtre identities to primary email
-Hugues Clouâtre <hugues@linux.com> <15008125+huguesclouatre@users.noreply.github.com>
-Hugues Clouâtre <hugues@linux.com> <hugues.clouatre@slalom.com>
-Hugues Clouâtre <hugues@linux.com> <15008125+clouatre@users.noreply.github.com>
-Hugues Clouâtre <hugues@linux.com> <hugues+mcp@linux.com>

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -154,12 +154,6 @@ SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = ".mailmap"
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
 path = "tests/conftest.py"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 math-mcp-learning-server Contributors"


### PR DESCRIPTION
## Summary

Removes `.mailmap` and its corresponding REUSE annotation. The GitHub contributor identity caching bug that necessitated the file has been fixed upstream.

## Changes

- `.mailmap` deleted
- `REUSE.toml`: removed `.mailmap` annotation block