### PR TITLE
docs: mention OpenSSF Best Practices silver in README and SECURITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and contr
 
 ## Security
 
+- **OpenSSF Best Practices Silver** - Fewer than 1% of open source projects reach this level
+- **REUSE/SPDX** - License compliance for all files
+- **Signed Commits** - GPG-signed commits required
+- **Dependency Scanning** - Automated updates via Renovate
+
 The `calculate` tool uses restricted `eval()` with a whitelist of allowed characters and functions, restricted global scope (only `math` module and `abs`), and no access to dangerous built-ins or imports. All tool inputs are validated with Pydantic models. File operations are restricted to the designated workspace directory. Complete type hints and validation are enforced for all operations.
 
 ## Links

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,6 +72,24 @@ Include:
 - We will publicly disclose the vulnerability after a fix is released
 - We will credit you for the discovery (unless you prefer to remain anonymous)
 
+## Supply Chain Security
+
+### OpenSSF Best Practices
+
+**OpenSSF Best Practices Silver certified.** Fewer than 1% of open source projects reach this level. See [project criteria](https://www.bestpractices.dev/projects/12334).
+
+### REUSE/SPDX
+
+All files carry SPDX license headers, verified by the [REUSE API](https://api.reuse.software/info/github.com/clouatre-labs/math-mcp-learning-server).
+
+### Signed Commits
+
+GPG-signed commits are required on all branches.
+
+### Dependency Scanning
+
+Automated dependency updates via Renovate, including GitHub Actions pins.
+
 ## Security Best Practices
 
 This project implements several security measures:


### PR DESCRIPTION
## Summary

Documents the OpenSSF Best Practices Silver certification, noting that fewer than 1% of open source projects reach this level.

## Changes

- `README.md` - Expanded the Security section with a bullet list covering the Silver badge, REUSE/SPDX, signed commits, and Renovate scanning
- `SECURITY.md` - Added a new Supply Chain Security section with subsections for OpenSSF, REUSE, signed commits, and dependency scanning

## Test plan

- [ ] No code changes; docs only