### PR TITLE
docs: migrate REUSE and OpenSSF badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
   <a href="https://pypi.org/project/math-mcp-learning-server/"><img alt="PyPI" src="https://img.shields.io/pypi/v/math-mcp-learning-server?style=for-the-badge&color=3b82f6" height="20"></a>
   <a href="https://pypi.org/project/math-mcp-learning-server/"><img alt="Python" src="https://img.shields.io/pypi/pyversions/math-mcp-learning-server?style=for-the-badge" height="20"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg?style=for-the-badge" height="20"></a>
-  <a href="https://api.reuse.software/info/github.com/clouatre-labs/math-mcp-learning-server"><img alt="REUSE" src="https://api.reuse.software/badge/github.com/clouatre-labs/math-mcp-learning-server" height="20"></a>
-  <a href="https://www.bestpractices.dev/projects/12334"><img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/12334/badge" height="20"></a>
+  <a href="https://api.reuse.software/info/github.com/clouatre-labs/math-mcp-learning-server"><img alt="REUSE" src="https://img.shields.io/reuse/compliance/github.com/clouatre-labs/math-mcp-learning-server?style=for-the-badge" height="20"></a>
+  <a href="https://www.bestpractices.dev/projects/12334"><img alt="OpenSSF Best Practices" src="https://img.shields.io/cii/level/12334?style=for-the-badge" height="20"></a>
 </p>
 
 <p align="center">Educational MCP server with 17 tools, persistent workspace, and cloud hosting. Built with <a href="https://gofastmcp.com">FastMCP</a> and the official <a href="https://github.com/modelcontextprotocol/python-sdk">Model Context Protocol Python SDK</a>.</p>


### PR DESCRIPTION
Migrate REUSE and OpenSSF Best Practices badges from their native image endpoints to shields.io for consistent `for-the-badge` style across all badges in the README header.

- REUSE: `img.shields.io/reuse/compliance/...`
- OpenSSF: `img.shields.io/cii/level/12334`

Side effect: resolves the OpenSSF badge caching issue (shields.io TTL ~1 hour).