### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,48 @@
+---
+name: Bug
+about: Report a defect or unexpected behavior
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+## Summary
+<!-- 1-2 sentences: what is broken? Symptom, not suspected cause. -->
+
+## Steps to Reproduce
+<!-- Exact steps to trigger the bug. Include tool name, inputs, and MCP client. -->
+
+1.
+2.
+3.
+
+## Expected Behavior
+<!-- What should happen? -->
+
+## Actual Behavior
+<!-- What actually happens? -->
+
+```
+<paste error output or stack trace here>
+```
+
+## Environment
+
+- OS:
+- Python version: `python --version`
+- Package version: check `pyproject.toml`
+- MCP client: Claude Desktop / goose / other
+- Tool or resource called:
+
+## Root Cause Analysis
+<!-- Optional: hypothesis with file path and line range. -->
+
+## Acceptance Criteria
+
+- [ ] Bug is reproducible with provided steps
+- [ ] Root cause identified
+- [ ] Fix implemented and verified
+- [ ] Regression test added
+- [ ] All tests pass (`uv run pytest tests/ -v`)
+- [ ] Linting passes (`uv run ruff check src/ tests/`)
+- [ ] Commit GPG signed and DCO signed-off

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/orgs/clouatre-labs/discussions
+    about: Ask questions and discuss ideas here.
+  - name: Report a Security Vulnerability
+    url: https://github.com/clouatre-labs/math-mcp-learning-server/security/advisories/new
+    about: Please report security vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,27 @@
+---
+name: Documentation
+about: Improve or add documentation
+title: "[DOCS] "
+labels: documentation
+assignees: ""
+---
+
+## Summary
+<!-- 1-2 sentences: what to create or improve and why. -->
+
+## Location
+<!-- File path or section in existing doc. -->
+
+## Current State
+<!-- What exists today and what is missing or incomplete. -->
+
+## Proposed Changes
+<!-- What to add or update. -->
+
+## Acceptance Criteria
+
+- [ ] Documentation is accurate and complete
+- [ ] Consistent with existing style and conventions
+- [ ] No broken links or references
+- [ ] Examples verified (if applicable)
+- [ ] Commit GPG signed and DCO signed-off

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,29 @@
+---
+name: Feature
+about: Propose a new feature or enhancement
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+## Summary
+<!-- 1-2 sentences: what to build and what need it addresses. -->
+
+## Context
+<!-- Why does this matter? Link related issues or ADRs. -->
+
+## Implementation Notes
+<!-- Key decisions, patterns to follow, relevant file paths. -->
+
+## Acceptance Criteria
+
+- [ ] Feature implemented per summary
+- [ ] Follows project conventions (see `docs/ARCHITECTURE.md`)
+- [ ] All existing tests pass (`uv run pytest tests/ -v`)
+- [ ] Linting passes (`uv run ruff check src/ tests/`)
+- [ ] New tests cover happy path and at least one edge case
+- [ ] Documentation updated (if applicable)
+- [ ] Commit GPG signed and DCO signed-off
+
+## Not In Scope
+<!-- Explicit boundaries to prevent scope creep. -->

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,24 @@
+---
+name: Refactor
+about: Improve code quality without changing behavior
+title: "[REFACTOR] "
+labels: refactor
+assignees: ""
+---
+
+## Summary
+<!-- 1-2 sentences: what to refactor and why. -->
+
+## Current State
+<!-- What is wrong or suboptimal today. Include file paths and line ranges. -->
+
+## Proposed Changes
+<!-- What to change and what pattern to follow. -->
+
+## Acceptance Criteria
+
+- [ ] Behavior unchanged (no functional diff)
+- [ ] All existing tests pass (`uv run pytest tests/ -v`)
+- [ ] Linting passes (`uv run ruff check src/ tests/`)
+- [ ] No new test gaps introduced
+- [ ] Commit GPG signed and DCO signed-off


### PR DESCRIPTION
## Description
Add structured issue templates for bug reports, feature requests, documentation, and refactors.

## Type of Change
- [x] Documentation update

## Testing
- [x] All tests pass locally (`uv run pytest tests/ -v`)
- [x] Code formatting checked (`uv run ruff format --check src/ tests/`)
- [x] Linting passed (`uv run ruff check src/ tests/`)

## Checklist
- [x] Created feature branch (not pushing to main directly)
- [x] Code follows project style guidelines (Ruff enforced)
- [x] Self-review completed
- [x] CI pipeline passes (lint + format + tests)

## Related Issues
N/A