### PR TITLE
refactor(complexity): reduce cyclomatic complexity of four functions below 10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 15
+max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S101", "F401"]  # Allow assert + unused imports in tests

--- a/src/math_mcp/eval.py
+++ b/src/math_mcp/eval.py
@@ -37,38 +37,34 @@ def _validate_expression_syntax(expression: str) -> None:
             raise ValueError(f"Function '{func}()' requires one parameter. Example: {func}(3.14)")
 
 
-def safe_eval_expression(expression: str) -> float:
-    """Safely evaluate mathematical expressions with restricted scope."""
-    # Validate syntax and provide helpful error messages
-    _validate_expression_syntax(expression)
-
-    # Remove whitespace
-    clean_expr = expression.replace(" ", "")
-
-    # Only allow safe characters (including comma for function parameters)
+def _check_expression_security(clean_expr: str, expression: str) -> None:
+    """Check for dangerous patterns and unsafe characters in expression."""
     allowed_chars = set("0123456789+-*/.(),e")
 
-    # Security check - log and block dangerous patterns
     if any(pattern in clean_expr.lower() for pattern in DANGEROUS_PATTERNS):
         logging.warning(f"Security: Blocked unsafe expression attempt: {expression[:50]}...")
         raise ValueError(
             "Expression contains forbidden operations. Only mathematical expressions are allowed."
         )
 
-    # Check for unsafe characters
     if not all(c in allowed_chars or c.isalpha() for c in clean_expr):
         raise ValueError(
             "Expression contains invalid characters. Use only numbers, +, -, *, /, (), and math functions."
         )
 
-    # Replace math functions with safe alternatives
+
+def _build_safe_expr(clean_expr: str) -> str:
+    """Replace math functions with safe alternatives (prefix with math. module)."""
     safe_expr = clean_expr
     for func in MATH_FUNCTIONS_ALL:
         if func in clean_expr:
-            if func != "abs":  # abs is built-in, others need math module
+            if func != "abs":
                 safe_expr = safe_expr.replace(func, f"math.{func}")
+    return safe_expr
 
-    # Evaluate with restricted globals
+
+def _eval_in_restricted_scope(safe_expr: str) -> float:
+    """Evaluate expression in restricted scope with safe globals."""
     try:
         allowed_globals = {"__builtins__": {"abs": abs}, "math": math}
         result = eval(safe_expr, allowed_globals, {})
@@ -85,6 +81,15 @@ def safe_eval_expression(expression: str) -> float:
         raise ValueError(f"Mathematical expression error: {str(e)}")
     except Exception as e:
         raise ValueError(f"Expression evaluation failed: {str(e)}")
+
+
+def safe_eval_expression(expression: str) -> float:
+    """Safely evaluate mathematical expressions with restricted scope."""
+    _validate_expression_syntax(expression)
+    clean_expr = expression.replace(" ", "")
+    _check_expression_security(clean_expr, expression)
+    safe_expr = _build_safe_expr(clean_expr)
+    return _eval_in_restricted_scope(safe_expr)
 
 
 def validate_variable_name(name: str) -> str:

--- a/src/math_mcp/tools/calculate.py
+++ b/src/math_mcp/tools/calculate.py
@@ -207,6 +207,72 @@ async def statistics(
     )
 
 
+def _validate_principal(principal: float) -> None:
+    """Validate principal amount."""
+    if principal <= 0:
+        raise ValueError("Principal must be greater than 0")
+
+
+def _validate_rate(rate: float) -> None:
+    """Validate interest rate."""
+    if rate < 0:
+        raise ValueError("Interest rate cannot be negative")
+    if rate > 1.0:
+        raise ValueError(
+            f"rate must be a decimal between 0.0 and 1.0 (e.g., 0.05 for 5%). "
+            f"Got {rate}. Did you mean {rate / 100:.4f}?"
+        )
+
+
+def _validate_time(time: float) -> None:
+    """Validate time period."""
+    if time <= 0:
+        raise ValueError("Time must be greater than 0")
+
+
+def _validate_compounds(compounds_per_year: int) -> None:
+    """Validate compounds per year."""
+    if compounds_per_year <= 0:
+        raise ValueError("Compounds per year must be greater than 0")
+
+
+async def _validate_compound_interest_inputs(
+    principal: float,
+    rate: float,
+    time: float,
+    compounds_per_year: int,
+    ctx: SkipValidation[Context | None] = None,
+) -> None:
+    """Validate compound interest inputs and raise ValueError for invalid parameters."""
+    try:
+        _validate_principal(principal)
+    except ValueError as e:
+        if ctx:
+            await ctx.warning(str(e))
+        raise
+
+    try:
+        _validate_rate(rate)
+    except ValueError as e:
+        if ctx:
+            await ctx.warning(str(e))
+        raise
+
+    try:
+        _validate_time(time)
+    except ValueError as e:
+        if ctx:
+            await ctx.warning(str(e))
+        raise
+
+    try:
+        _validate_compounds(compounds_per_year)
+    except ValueError as e:
+        if ctx:
+            await ctx.warning(str(e))
+        raise
+
+
 @calculate_mcp.tool(
     annotations={
         "title": "Compound Interest Calculator",
@@ -254,29 +320,7 @@ async def compound_interest(
             f"Calculating compound interest: ${principal:,.2f} @ {rate * 100}% for {time} years"
         )
 
-    if principal <= 0:
-        if ctx:
-            await ctx.warning(f"Invalid principal: {principal}")
-        raise ValueError("Principal must be greater than 0")
-    if rate < 0:
-        if ctx:
-            await ctx.warning(f"Negative rate: {rate}")
-        raise ValueError("Interest rate cannot be negative")
-    if rate > 1.0:
-        if ctx:
-            await ctx.warning(f"rate {rate} looks like a percentage not a decimal")
-        raise ValueError(
-            f"rate must be a decimal between 0.0 and 1.0 (e.g., 0.05 for 5%). "
-            f"Got {rate}. Did you mean {rate / 100:.4f}?"
-        )
-    if time <= 0:
-        if ctx:
-            await ctx.warning(f"Invalid time: {time}")
-        raise ValueError("Time must be greater than 0")
-    if compounds_per_year <= 0:
-        if ctx:
-            await ctx.warning(f"Invalid compounds_per_year: {compounds_per_year}")
-        raise ValueError("Compounds per year must be greater than 0")
+    await _validate_compound_interest_inputs(principal, rate, time, compounds_per_year, ctx)
 
     final_amount = principal * (1 + rate / compounds_per_year) ** (compounds_per_year * time)
     total_interest = final_amount - principal

--- a/src/math_mcp/tools/visualization.py
+++ b/src/math_mcp/tools/visualization.py
@@ -93,6 +93,36 @@ def validate_nested_array_groups(
     return None
 
 
+def _validate_plot_range(x_range: tuple[float, float], num_points: int) -> tuple[float, float]:
+    """Validate plot range and return (x_min, x_max)."""
+    x_min, x_max = x_range
+    if x_min >= x_max:
+        raise ValueError("x_range minimum must be less than maximum")
+    if num_points < 2:
+        raise ValueError("num_points must be at least 2")
+    return (x_min, x_max)
+
+
+async def _evaluate_expression_points(
+    x_values: Any, expression: str, ctx: SkipValidation[Context | None], num_points: int
+) -> list[float]:
+    """Evaluate expression for each x value with progress reporting."""
+    y_values = []
+    var_pattern = re.compile(r"\bx\b")
+    for i, x in enumerate(x_values):
+        if ctx and i % max(1, num_points // 10) == 0:
+            await ctx.report_progress(i, num_points, f"Evaluating points: {i}/{num_points}")
+
+        expr_with_value = var_pattern.sub(f"({x})", expression)
+        try:
+            y = await evaluate_with_timeout(expr_with_value)
+            y_values.append(y)
+        except ValueError:
+            y_values.append(float("nan"))
+
+    return y_values
+
+
 # === TOOLS: VISUALIZATION OPERATIONS ===
 
 
@@ -140,46 +170,20 @@ async def plot_function(
         plot_function("sin(x)", (-3.14, 3.14))
     """
 
-    # FastMCP Context logging
     if ctx:
         await ctx.info(f"Plotting function: {expression} over range {x_range}")
 
     try:
-        # Validate x_range
-        x_min, x_max = x_range
-        if x_min >= x_max:
-            raise ValueError("x_range minimum must be less than maximum")
-        if num_points < 2:
-            raise ValueError("num_points must be at least 2")
-
-        # Generate x values and evaluate expression
         import numpy as np
 
+        x_min, x_max = _validate_plot_range(x_range, num_points)
         x_values = np.linspace(x_min, x_max, num_points)
 
-        # Evaluate expression for each x value
-        y_values = []
-        var_pattern = re.compile(r"\bx\b")
-        for i, x in enumerate(x_values):
-            # Report progress at ~10% intervals
-            if ctx and i % max(1, num_points // 10) == 0:
-                await ctx.report_progress(i, num_points, f"Evaluating points: {i}/{num_points}")
+        y_values = await _evaluate_expression_points(x_values, expression, ctx, num_points)
 
-            # Replace x in expression with actual value using word boundaries
-            # to avoid corrupting function names like exp, max, hex
-            expr_with_value = var_pattern.sub(f"({x})", expression)
-            try:
-                y = await evaluate_with_timeout(expr_with_value)
-                y_values.append(y)
-            except ValueError:
-                # Handle domain errors (like sqrt of negative) or timeout
-                y_values.append(float("nan"))
-
-        # Report final progress
         if ctx:
             await ctx.report_progress(num_points, num_points, "Rendering plot")
 
-        # Delegate rendering to visualization helper
         image_bytes = visualization.create_function_plot(x_values.tolist(), y_values, expression)
 
         return Image(data=image_bytes, format="png")
@@ -247,42 +251,24 @@ async def create_histogram(
             error_type="validation_error",
         )
 
-    # Matplotlib is guaranteed to be available (decorator handles ImportError)
     if ctx:
         await ctx.info(f"Creating histogram with {len(data)} data points and {bins} bins")
 
     try:
-        # Validate inputs
-        if not data:
-            raise ValueError("Cannot create histogram with empty data")
-        if len(data) == 1:
-            raise ValueError("Histogram requires at least 2 data points")
+        _validate_histogram_data(data)
 
-        # Report initial progress
-        if ctx:
-            await ctx.report_progress(0, 3, "Validating inputs")
+        await _report_histogram_stage(ctx, 0, 3, "Validating inputs")
+        await _report_histogram_stage(ctx, 1, 3, "Calculating statistics")
 
-        # Stage 1: Calculate statistics
-        if ctx:
-            await ctx.report_progress(1, 3, "Calculating statistics")
+        mean_val, median_val, std_dev = _compute_histogram_stats(data)
 
-        import statistics as stats
-
-        mean_val = stats.mean(data)
-        median_val = stats.median(data)
-        std_dev = stats.stdev(data) if len(data) > 1 else 0
-
-        # Stage 2: Render visualization
-        if ctx:
-            await ctx.report_progress(2, 3, "Rendering histogram")
+        await _report_histogram_stage(ctx, 2, 3, "Rendering histogram")
 
         image_bytes = visualization.create_histogram_chart(
             data, bins, title, mean_val, median_val, std_dev
         )
 
-        # Stage 3: Complete
-        if ctx:
-            await ctx.report_progress(3, 3, "Complete")
+        await _report_histogram_stage(ctx, 3, 3, "Complete")
 
         return Image(data=image_bytes, format="png")
 
@@ -300,6 +286,34 @@ async def create_histogram(
             message=f"**Unexpected Error:** {str(e)}",
             error_type="unexpected_error",
         )
+
+
+def _validate_histogram_data(data: list[float]) -> None:
+    """Validate histogram data and raise ValueError for invalid inputs."""
+    if not data:
+        raise ValueError("Cannot create histogram with empty data")
+
+    if len(data) == 1:
+        raise ValueError("Histogram requires at least 2 data points")
+
+
+async def _report_histogram_stage(
+    ctx: SkipValidation[Context | None], stage: int, total: int, message: str
+) -> None:
+    """Report histogram progress stage."""
+    if ctx:
+        await ctx.report_progress(stage, total, message)
+
+
+def _compute_histogram_stats(data: list[float]) -> tuple[float, float, float]:
+    """Compute histogram statistics and return (mean, median, std_dev)."""
+    import statistics as stats
+
+    mean_val = stats.mean(data)
+    median_val = stats.median(data)
+    std_dev = stats.stdev(data) if len(data) > 1 else 0.0
+
+    return (mean_val, median_val, std_dev)
 
 
 @visualization_mcp.tool(


### PR DESCRIPTION
## Summary

Extract private helper functions to bring `safe_eval_expression`, `compound_interest`, `plot_function`, and `create_histogram` below McCabe 10. Lower `max-complexity` in `pyproject.toml` from 15 to 10.

Closes #322

## Changes

| File | Change |
|---|---|
| `src/math_mcp/eval.py` | Extract `_check_expression_security`, `_build_safe_expr`, `_eval_in_restricted_scope` |
| `src/math_mcp/tools/calculate.py` | Extract `_validate_principal`, `_validate_rate`, `_validate_time`, `_validate_compounds_per_year`, `_validate_compound_interest_inputs` (async) |
| `src/math_mcp/tools/visualization.py` | Extract `_validate_plot_range`, `_evaluate_expression_points` (async), `_validate_histogram_data`, `_compute_histogram_stats`, `_report_histogram_stage` |
| `pyproject.toml` | Lower `max-complexity` from 15 to 10 |

## Test plan

- [x] `uv run ruff check --select C901 src/` passes (no violations)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run pyright src/` clean (0 errors)
- [x] All existing sync tests pass without modification
- [x] No public API changes
- [x] No new dependencies