### PR TITLE
style(assets): format math_demo.py to satisfy ruff format check

### DIFF
--- a/assets/math_demo.py
+++ b/assets/math_demo.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2024 Hugues Clouâtre
 # SPDX-License-Identifier: Apache-2.0
 """Demo script for math-mcp-learning-server. Used by assets/demo.tape only."""
+
 import asyncio
 import sys
 


### PR DESCRIPTION
## Summary

- Adds missing blank line after module docstring in `assets/math_demo.py` to satisfy `ruff format --check`
- Fixes the CI failure blocking Renovate PR #350

## Changes

- `assets/math_demo.py`: blank line inserted after docstring (ruff formatter requirement)

## Test plan

- [x] `ruff format --check assets/math_demo.py` passes locally
- [x] `ruff check assets/math_demo.py` passes locally