### PR TITLE
docs: fix broken demo GIF URL and DEMO.md link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 ## Demo
 
-![math-mcp Demo](https://raw.githubusercontent.com/clouatre-labs/math-mcp-learning-server/docs/readme-demo/assets/demo.gif)
+![math-mcp Demo](https://raw.githubusercontent.com/clouatre-labs/math-mcp-learning-server/main/assets/demo.gif)
 
-See [docs/DEMO.md](docs/DEMO.md) for instructions to record your own demo.
+See [CONTRIBUTING.md](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md#demo-gif) for instructions to record your own demo.
 
 ## Quick Start
 
@@ -54,7 +54,7 @@ Connect your MCP client to the hosted server:
 }
 ```
 
-For other installation options (basic, scientific-only, plotting-only), see [CONTRIBUTING.md](CONTRIBUTING.md).
+For other installation options (basic, scientific-only, plotting-only), see [CONTRIBUTING.md](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md).
 
 ## Tools
 
@@ -97,7 +97,7 @@ See [Usage Examples](https://github.com/clouatre-labs/math-mcp-learning-server/b
 
 ## Development
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and contribution guidelines.
+See [CONTRIBUTING.md](https://github.com/clouatre-labs/math-mcp-learning-server/blob/main/CONTRIBUTING.md) for development setup, testing, and contribution guidelines.
 
 ## Security
 


### PR DESCRIPTION
## Summary

Fix two issues introduced in the `docs/readme-demo` feature branch:

- Demo GIF URL hardcoded the feature branch as the `raw.githubusercontent.com` ref; after merge the file lives on `main`, causing HTTP 404
- Link to `docs/DEMO.md` was left in README after that file was intentionally deleted (instructions moved to `CONTRIBUTING.md`)

All relative links in `README.md` have been replaced with absolute URLs so the page renders correctly on pypi.org (which has no repo context for relative path resolution).

## Changes

- `README.md` line 21: relative `assets/demo.gif` -> absolute `raw.githubusercontent.com/.../main/assets/demo.gif`
- `README.md` line 23: relative `CONTRIBUTING.md#demo-gif` -> absolute `github.com/.../blob/main/CONTRIBUTING.md#demo-gif`
- `README.md` line 57: relative `CONTRIBUTING.md` -> absolute URL
- `README.md` line 100: relative `CONTRIBUTING.md` -> absolute URL

## Test plan

- [x] No relative links remain in `README.md`
- [x] GIF URL returns HTTP 200 (`raw.githubusercontent.com/...main/assets/demo.gif`)
- [x] `CONTRIBUTING.md` anchor `#demo-gif` resolves
- [x] Only `README.md` modified
- [x] GPG-signed + DCO sign-off
