### PR TITLE
chore(deps): bump aptu action to v0.8.6

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run Aptu Triage
-        uses: clouatre-labs/aptu@73b96b78cf358cd085c26fac86613a450168d3b6 # v0.8.5
+        uses: clouatre-labs/aptu@93ca6d6613ebc2bb47f92caf48d10509ad0920e3 # v0.8.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Review PR
-        uses: clouatre-labs/aptu@73b96b78cf358cd085c26fac86613a450168d3b6 # v0.8.5
+        uses: clouatre-labs/aptu@93ca6d6613ebc2bb47f92caf48d10509ad0920e3 # v0.8.6
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump `clouatre-labs/aptu` reusable workflow from v0.8.5 to v0.8.6.

SHA: `93ca6d6613ebc2bb47f92caf48d10509ad0920e3`

Changelog: https://github.com/clouatre-labs/aptu/releases/tag/v0.8.6
