### PR TITLE
chore: pin fastmcp<4.0.0, annotate validated_tool, clarify session state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Environment :: Console",
 ]
 dependencies = [
-    "fastmcp>=3.2.4",
+    "fastmcp>=3.2.4,<4.0.0",
     "pydantic>=2.13.3",
     "pydantic-settings>=2.14.0",
 ]

--- a/src/math_mcp/settings.py
+++ b/src/math_mcp/settings.py
@@ -1,5 +1,6 @@
 """Configuration management for Math MCP Server."""
 
+from collections.abc import Callable
 from typing import Final
 
 from pydantic import Field, field_validator, validate_call
@@ -54,8 +55,20 @@ class MathMCPSettings(BaseSettings):
 # === CUSTOM DECORATOR FOR TOOL VALIDATION ===
 
 
-def validated_tool(func):
-    """Apply Pydantic validation to tool functions with Context support."""
+def validated_tool(func: Callable) -> Callable:
+    """Apply Pydantic validation to tool functions with Context support.
+
+    Wraps a tool function with ``validate_call`` so that all arguments are
+    validated by Pydantic before the function body executes.
+    ``arbitrary_types_allowed=True`` is required to accept FastMCP's
+    ``Context`` object, which is not a Pydantic model.
+
+    Usage::
+
+        @validated_tool
+        async def my_tool(x: int, ctx: Context | None = None) -> str:
+            ...
+    """
     return validate_call(config={"arbitrary_types_allowed": True})(func)
 
 

--- a/src/math_mcp/tools/_session.py
+++ b/src/math_mcp/tools/_session.py
@@ -20,6 +20,11 @@ async def _get_or_create_session_id(ctx: Context | None) -> str | None:
     if ctx is None:
         return None
 
+    # ctx.get_state / ctx.set_state is FastMCP application-level state stored in
+    # the per-connection Context object. It is unrelated to the MCP protocol-level
+    # Mcp-Session-Id header removed in the 2026-07-28 spec revision. Workspace
+    # data is persisted on the filesystem, so it survives across connections
+    # regardless of transport statefulness.
     session_id = await ctx.get_state("session_id")
     if session_id is None:
         session_id = str(uuid.uuid4())

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=3.2.4" },
+    { name = "fastmcp", specifier = ">=3.2.4,<4.0.0" },
     { name = "matplotlib", marker = "extra == 'plotting'", specifier = ">=3.10.6" },
     { name = "numpy", marker = "extra == 'plotting'", specifier = ">=2.4.4" },
     { name = "numpy", marker = "extra == 'scientific'", specifier = ">=2.4.4" },


### PR DESCRIPTION
## Summary

Closes #413
Closes #417

Two chore items from the 2026-07-27 audit (v0.12.1).

## Changes

**`pyproject.toml`**
- Pin `fastmcp>=3.2.4,<4.0.0` to guard against the FastMCP v4/MCPServer rewrite tracking the 2026-07-28 stateless MCP spec revision. A `uv lock --upgrade` or Renovate bump could otherwise pull in a breaking major version undetected.

**`src/math_mcp/settings.py`**
- Add `Callable` type annotations and a full docstring to `validated_tool`. The function is actively used as a decorator across all four tool modules; the missing annotations were the only outstanding F07 item.

**`src/math_mcp/tools/_session.py`**
- Add an inline comment above `ctx.get_state` / `ctx.set_state` clarifying that this is FastMCP application-level per-connection state, distinct from the MCP protocol-level `Mcp-Session-Id` header removed in the 2026-07-28 spec. Workspace data persists on the filesystem regardless of transport statefulness.

## Verification

- `uv run ruff check src/ tests/` -- clean
- `uv run ruff format --check src/ tests/` -- clean
- `uv run pytest -v` -- 45 passed, 76 failed, 13 skipped (baseline unchanged; pre-existing failures unrelated to these changes)
