### PR TITLE
chore(release): bump version to 0.12.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.12.1"
+version = "0.12.2"
 description = "Educational MCP server for math operations, statistics, visualization, and persistent workspaces. Built with FastMCP."
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
## Release 0.12.2

Bumps `pyproject.toml` version to `0.12.2`. The tag and PyPI publish are triggered by the release workflow after merge.

### What's Changed

#### Features
- **aptu:** Add `ai` block to `aptu.yml` (required after aptu-github-app#61) (#409)

#### Fixes
- **deps:** Pin `fastmcp<4.0.0`, annotate `validated_tool`, clarify session state (#420)

#### Docs
- **README:** Improve README and add VHS demo GIF (#348)
- **Complexity:** Document cyclomatic complexity threshold and suppression pattern (#347)
- **AI policy:** Add `AI_POLICY.md`, soften enforcement language, clarify opening paragraph (#343, #344, #345)
- **Audit:** 2026-07-27 quality and freshness audit (#419)

#### CI
- **aptu:** Add `.github/aptu.yml` to enable aptu triage and review (#397)
- **ruff:** Update dependency to `>=0.16.0,<0.17.0` (#410)

#### Chores
- **deps:** Pin `fastmcp<4.0.0` and lock file maintenance (#381, #420)
- **deps:** Update `setup-uv` action to v8.3.0, v8.3.1, v8.3.2, v9 (#400, #401, #402, #408)
- **deps:** Update `actions/cache` to v6, v6.1.0 (#396, #398)
- **deps:** Update `actions/checkout` digest (#406)
- **deps:** Update `actions/setup-node` to v7 (#403, #404)
- **deps:** Update `actions/upload-artifact` digest (#354)
- **deps:** Update `astral-sh/ruff-action` to v4 (#357)
- **deps:** Update `clouatre-labs/aptu` action to v0.2.22, v0.3.0--v0.4.2 (#346, #355--#364)
- **deps:** Update `dorny/paths-filter` digest (#399)
- **deps:** Update `ossf/scorecard-action` to v2.4.4 (#411)
- **deps:** Update `pypa/gh-action-pypi-publish` to v1.14.0, v1.14.1 (#353, #407)
- **deps:** Update `taiki-e/create-gh-release-action` digests (#349, #361)
- **deps:** Update `zizmorcore/zizmor-action` to v0.5.3, v0.6.0, v0.6.1 (#359, #405, #412)
- **assets:** Sort imports and format `math_demo.py` (#351, #352)

**Full Changelog:** https://github.com/clouatre-labs/math-mcp-learning-server/compare/v0.12.1...v0.12.2
