### PR TITLE
fix(ci): use ubuntu-24.04 for PyPI publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: [create-release, build-and-attest]
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     if: needs.create-release.outputs.dry_run != 'true'
     environment:
       name: pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.12.1"
+version = "0.12.2"
 description = "Educational MCP server for math operations, statistics, visualization, and persistent workspaces. Built with FastMCP."
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
## Fix PyPI publish on arm64 runner

`pypa/gh-action-pypi-publish` ships a `linux/amd64`-only Docker image. Running it on `ubuntu-24.04-arm` fails at container startup with `exec format error`.

Switch the `publish` job to `ubuntu-24.04` (x86_64). All other release jobs remain on `ubuntu-24.04-arm`.

### Root cause

The `v0.12.2` release workflow failed at the `Publish to PyPI` step:

```
exec /app/twine-upload.sh: exec format error
```

The Docker image `ghcr.io/pypa/gh-action-pypi-publish` has no `arm64` variant. The `publish` job must run on an amd64 runner.

### Change

- `publish` job: `ubuntu-24.04-arm` -> `ubuntu-24.04`
- All other jobs unchanged
