### PR TITLE
fix(ci): download linux_arm64 mcp-publisher on arm64 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
         run: |
           VERSION=$(curl -sI https://github.com/modelcontextprotocol/registry/releases/latest | grep -i '^location:' | sed 's/.*tag\///' | tr -d '\r\n')
           echo "Installing mcp-publisher ${VERSION}"
-          curl -sSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          curl -sSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_arm64.tar.gz" | tar xz mcp-publisher
           ./mcp-publisher --version
 
       - name: Login to MCP Registry


### PR DESCRIPTION
## Fix MCP Registry publish on arm64 runner

`mcp-publisher_linux_amd64.tar.gz` cannot execute on `ubuntu-24.04-arm` runners.
Switch the download to `linux_arm64` to match the runner architecture.

### Root cause

The `v0.12.2` release workflow failed at `Install MCP Publisher`:

```
./mcp-publisher: cannot execute binary file: Exec format error
```

The step downloads the `amd64` tarball unconditionally, but the `mcp-registry` job runs on `ubuntu-24.04-arm`.

### Change

- `mcp-publisher_linux_amd64.tar.gz` -> `mcp-publisher_linux_arm64.tar.gz`
- Verified `linux_arm64` asset exists in `v1.8.0` release
