### PR TITLE
fix(ci): use gh release download for mcp-publisher install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,9 +194,7 @@ jobs:
 
       - name: Install MCP Publisher
         run: |
-          VERSION=$(curl -sI https://github.com/modelcontextprotocol/registry/releases/latest | grep -i '^location:' | sed 's/.*tag\///' | tr -d '\r\n')
-          echo "Installing mcp-publisher ${VERSION}"
-          curl -sSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_arm64.tar.gz" | tar xz mcp-publisher
+          gh release download --repo modelcontextprotocol/registry --pattern 'mcp-publisher_linux_arm64.tar.gz' -O - | tar xz mcp-publisher
           ./mcp-publisher --version
 
       - name: Login to MCP Registry


### PR DESCRIPTION
## Summary

Replace the two-step curl version-detection + curl download in the mcp-registry job's Install MCP Publisher step with a single `gh release download` call. Removes ~3 lines and eliminates silent-failure risk.

## Changes

- `.github/workflows/release.yml`: Replaced 3-line curl version-detection + curl download block with single `gh release download` call

## Why

The previous approach used curl piped directly to tar, which fails silently on HTTP errors. `gh release download` fails loudly, is authenticated, and is idiomatic for GitHub-hosted releases. Omitting the tag downloads from latest automatically; `--pattern` selects the arm64 asset; `-O -` pipes to tar.

## Follow-up

This addresses the review comment from aptu-dev[bot] on PR #423.

## Test plan

- [x] Linter clean (ruff check passed)
- [x] Security scan clean (no findings)
- [x] Only release.yml changed (verified via git diff)
