### PR TITLE
docs(audit): MCP 2026-07-28 spec alignment audit

### DIFF
--- a/docs/audit/2026-08-01-mcp-spec-2026-07-28.md
+++ b/docs/audit/2026-08-01-mcp-spec-2026-07-28.md
@@ -83,7 +83,10 @@ An additional conformance issue: under 2026-07-28 servers MUST NOT emit `notific
 
 ### C02 -- DEPRECATED-IN-USE (medium) -- Protocol logging notifications in calculate tools
 
-**File:** `src/math_mcp/tools/calculate.py` (lines ~107, 159, 165, 168, 174, 192, 260, 326, 353, 363, 367)
+**File:** `src/math_mcp/tools/calculate.py` (lines ~107, 159, 168, 174, 260, 326, 353, 363, 367)
+
+Note: lines 165 and 192 are `if ctx:` guards for `ctx.report_progress` calls, not logging
+notifications, and are excluded from this finding.
 
 `calc_expression`, `calc_statistics`, `calc_interest`, `calc_units` call `ctx.info`/`ctx.warning` unconditionally on every invocation. Same Logging-feature deprecation and unconditional-emission concern as C01. This is the highest call-volume file in the server.
 
@@ -93,7 +96,10 @@ An additional conformance issue: under 2026-07-28 servers MUST NOT emit `notific
 
 ### C03 -- DEPRECATED-IN-USE (medium) -- Protocol logging notifications in visualization tools
 
-**File:** `src/math_mcp/tools/visualization.py` (lines ~169, 188, 195, 244, 270, 276, 283, 343, 423, 507, 581)
+**File:** `src/math_mcp/tools/visualization.py` (lines ~169, 188, 195, 244, 276, 283, 343, 423, 507, 581)
+
+Note: line 270 is `ctx.report_progress`, not a logging notification, and is excluded from this
+finding. The `ctx.error` calls are at 276 and 283.
 
 All `plot_*` tools emit `ctx.info()` on start and `ctx.error()` on failure. Under 2026-07-28 these map to `notifications/message`. Error paths are especially problematic: a `ctx.error()` call on failure does not constitute a protocol-level error response; the tool may silently appear to succeed from the client's perspective while only emitting a log notification.
 
@@ -195,7 +201,13 @@ Plot tools use `ctx.report_progress` for progress notifications during `asyncio.
 
 **File:** `pyproject.toml` (line 24)
 
-`fastmcp>=3.2.4,<4.0.0` was the F01 fix from the 2026-07-27 audit. This limits exposure to an uncoordinated jump into FastMCP's stateless-core rework. No action required.
+`fastmcp>=3.2.4,<4.0.0` was the F01 fix from the 2026-07-27 audit. This limits exposure to an
+uncoordinated jump into FastMCP's stateless-core rework.
+
+**Update (2026-08-01):** FastMCP 4.0.0b1 has been released with 2026-07-28 protocol support. The
+`<4.0.0` ceiling pin will block it. Complete C01-C05 (Logging migration) before relaxing the pin;
+doing so first ensures the MUST-NOT unconditional-emission violation is resolved before the
+application is exposed to FastMCP's dual-era serving layer.
 
 ---
 

--- a/docs/audit/2026-08-01-mcp-spec-2026-07-28.md
+++ b/docs/audit/2026-08-01-mcp-spec-2026-07-28.md
@@ -1,0 +1,260 @@
+# Audit: MCP 2026-07-28 Specification Alignment
+
+Date: 2026-08-01  
+Commit: 7b89be0  
+Version: v0.12.2  
+Toolchain: Python 3.14 / FastMCP >=3.2.4,<4.0.0 / uv
+
+## Purpose
+
+Point-in-time audit of `math-mcp-learning-server` v0.12.2 against the MCP 2026-07-28 specification, published as final on July 28, 2026. This is the largest MCP revision since launch and the first with a formal feature lifecycle and deprecation policy.
+
+Scope: breaking changes, deprecated-in-use patterns, opportunities, and cross-reference with the open GitHub issues present at audit time.
+
+## Background: What Changed in MCP 2026-07-28
+
+Six Specification Enhancement Proposals (SEPs) drove the release.
+
+**Breaking removals (existing servers must adapt as clients upgrade):**
+
+| Removed | SEP | Replacement |
+|---|---|---|
+| `initialize` / `initialized` handshake | SEP-2575 | Protocol version + capabilities in `_meta` per-request; `server/discover` |
+| `Mcp-Session-Id` header + protocol session | SEP-2567 | Explicit handles passed as tool arguments |
+| `ping` method | SEP-2575 | `tools/list` or lightweight health check |
+| `logging/setLevel` method | SEP-2575 | `io.modelcontextprotocol/logLevel` in `_meta` per-request |
+| `tasks/list` + blocking `tasks/result` | SEP-2663 | `io.modelcontextprotocol/tasks` extension; poll via `tasks/get` |
+| Required `Mcp-Method` / `Mcp-Name` headers on Streamable HTTP POSTs | SEP-2243 | (new requirement, not a removal) |
+
+**Error code renumbering (breaking for clients matching on numeric codes):**
+
+| Old code | New code | Name |
+|---|---|---|
+| -32002 | -32602 | Resource not found -> standard Invalid Params |
+| -32001 | -32020 | HeaderMismatch |
+| -32003 | -32021 | MissingRequiredClientCapability |
+| -32004 | -32022 | UnsupportedProtocolVersion |
+
+**Deprecated (12-month minimum window before removal eligible):**
+
+| Feature | SEP | Migration |
+|---|---|---|
+| Logging (`notifications/message`, `logging/setLevel`) | SEP-2577 | stderr (stdio) or OpenTelemetry |
+| Roots | SEP-2577 | Tool parameters or server config |
+| Sampling | SEP-2577 | Direct LLM provider API calls |
+| HTTP+SSE transport | SEP-2596 | Streamable HTTP |
+| Dynamic Client Registration | SEP-2577 | CIMD (Client-Initiated Metadata Discovery) |
+
+**New optional features:**
+
+- `ttlMs` + `cacheScope` on `tools/list` and resource reads for client-side caching
+- W3C Trace Context (`traceparent`, `tracestate`, `baggage`) in `_meta` for distributed tracing
+- Multi Round-Trip Requests (MRTR) pattern replacing server-initiated requests
+- `io.modelcontextprotocol/tasks` extension (poll-based async tasks)
+- `io.modelcontextprotocol/apps` extension (interactive HTML surfaces)
+- Extensions framework (reverse-DNS IDs, negotiated via `capabilities`)
+- JSON Schema 2020-12 for tool input schemas
+- `subscriptions/listen` replacing HTTP GET endpoint for change notifications
+
+## Methodology
+
+Static analysis via `analyze_directory`, `analyze_file`, `analyze_module` on the full source tree. No code was modified. Findings are classified:
+
+- **BREAKING**: will fail with a 2026-07-28-only client once FastMCP absorbs the spec
+- **DEPRECATED-IN-USE**: uses a deprecated feature; works today, on 12-month removal clock
+- **OPPORTUNITY**: new spec capability this server could adopt
+- **CLEAN**: already aligned; no action required
+
+---
+
+## Findings
+
+### C01 -- DEPRECATED-IN-USE (medium) -- Protocol logging notifications in matrix tools
+
+**File:** `src/math_mcp/tools/matrix.py` (lines ~168, 223, 267, 316, 335, 391, 400, 420)
+
+`matrix_multiply`, `matrix_transpose`, `matrix_determinant`, `matrix_inverse`, `matrix_eigenvalues` all call `await ctx.info(...)` and `await ctx.warning(...)` unconditionally on every invocation. These emit MCP `notifications/message`, which is the protocol-level Logging feature deprecated by SEP-2577.
+
+An additional conformance issue: under 2026-07-28 servers MUST NOT emit `notifications/message` for requests that did not include `io.modelcontextprotocol/logLevel` in `_meta`. No such gating exists; all ctx log calls fire regardless of client opt-in.
+
+**Migration:** Replace `ctx.info`/`ctx.warning` calls with Python's `logging` module (already used in `server.py`, `eval.py`, `persistence/workspace.py`). If protocol-level logging notifications are retained during the deprecation window, gate emission on presence of `io.modelcontextprotocol/logLevel` in the request `_meta`. Error-level calls in visualization (`ctx.error`) should raise a proper tool error response rather than relying on a log notification for failure visibility.
+
+---
+
+### C02 -- DEPRECATED-IN-USE (medium) -- Protocol logging notifications in calculate tools
+
+**File:** `src/math_mcp/tools/calculate.py` (lines ~107, 159, 165, 168, 174, 192, 260, 326, 353, 363, 367)
+
+`calc_expression`, `calc_statistics`, `calc_interest`, `calc_units` call `ctx.info`/`ctx.warning` unconditionally on every invocation. Same Logging-feature deprecation and unconditional-emission concern as C01. This is the highest call-volume file in the server.
+
+**Migration:** Same as C01.
+
+---
+
+### C03 -- DEPRECATED-IN-USE (medium) -- Protocol logging notifications in visualization tools
+
+**File:** `src/math_mcp/tools/visualization.py` (lines ~169, 188, 195, 244, 270, 276, 283, 343, 423, 507, 581)
+
+All `plot_*` tools emit `ctx.info()` on start and `ctx.error()` on failure. Under 2026-07-28 these map to `notifications/message`. Error paths are especially problematic: a `ctx.error()` call on failure does not constitute a protocol-level error response; the tool may silently appear to succeed from the client's perspective while only emitting a log notification.
+
+**Migration:** Same as C01. Error paths must raise `McpError` or return a structured error result, not rely on `ctx.error()`.
+
+---
+
+### C04 -- DEPRECATED-IN-USE (low) -- Protocol logging notifications in resource handlers
+
+**File:** `src/math_mcp/resources.py` (lines ~39, 78, 110, 128, 282)
+
+`list_available_functions`, `get_calculation_history`, `get_workspace`, `list_tools_catalog`, `list_variable_names` all call `await ctx.info(...)` unconditionally on access. Same Logging deprecation concern; lower severity because resources are read-mostly and lower-frequency than tool calls.
+
+**Migration:** Migrate to module-level `logging.getLogger(...)` calls or drop for resource reads.
+
+---
+
+### C05 -- DEPRECATED-IN-USE (low) -- Protocol logging notifications in persistence tools
+
+**File:** `src/math_mcp/tools/persistence.py` (lines ~98, 151, 158)
+
+`save_calculation` and `load_variable` emit `ctx.info` on every call and `ctx.warning` when a variable is not found. Same Logging deprecation pattern.
+
+**Migration:** Same as C01.
+
+---
+
+### C06 -- CLEAN (info) -- No removed-feature protocol code in server core
+
+**File:** `src/math_mcp/server.py`
+
+`server.py` delegates all protocol handshake, session, and logging-level negotiation to FastMCP internals. No application-level implementation of `initialize`/`initialized`, `ping`, `tasks/list`, `logging/setLevel`, or any of the renumbered error codes (-32001/-32002/-32003/-32004) was found anywhere under `src/`. The breaking changes from removed features are FastMCP's responsibility to absorb, not the application layer's.
+
+**Note:** This is contingent on FastMCP 3.x shipping 2026-07-28-compliant releases within the `>=3.2.4,<4.0.0` pin range. Monitor the FastMCP changelog when FastMCP ships its 2026-07-28 alignment. The upper-bound pin (already addressed in issue #F01 from the 2026-07-27 audit) limits exposure to an uncoordinated major-version jump.
+
+---
+
+### C07 -- CLEAN (info) -- ctx.get_state/set_state correctly distinct from removed Mcp-Session-Id
+
+**File:** `src/math_mcp/tools/_session.py` (lines 8-33)
+
+`_get_or_create_session_id` uses FastMCP's per-connection `Context.get_state`/`set_state`, which is application-level state scoped to the client connection object, not the protocol-level `Mcp-Session-Id` header removed by SEP-2567. The file already carries an inline comment (added in the 2026-07-27 audit remediation) explicitly noting the distinction.
+
+**Residual risk:** Once FastMCP ships a stateless transport aligned with SEP-2567, sequential requests from the same logical client may route to different server instances, breaking the per-connection state assumption. Workspace state is filesystem-backed and survives instance routing; the session ID in `_session.py` is used only as a workspace namespace, so the risk is limited but worth re-verifying at FastMCP upgrade time.
+
+---
+
+### C08 -- BREAKING (low) -- test_http_ping asserts on a removed method
+
+**File:** `tests/test_http_integration.py` (lines ~15-18)
+
+`test_http_ping` calls `await http_client.ping()` and asserts the result is `True`. The `ping` method is removed in 2026-07-28 (SEP-2575). This test currently passes because FastMCP 3.x still implements `ping`, but it will break once FastMCP drops `ping` in its 2026-07-28 alignment release.
+
+**Migration:** Once FastMCP removes `ping`, delete this test and replace it with a `tools/list` or `resources/list` liveness check. No action needed today; track the FastMCP 3.x changelog.
+
+---
+
+### C09 -- BREAKING (info) -- Rate-limit test magic numbers assume the old handshake request count
+
+**File:** `tests/test_math_operations.py` (line ~357)
+
+A comment in the rate-limit test reads: "Client init consumes 3 of 10 requests: initialize, notifications/initialized, tools/list". Under SEP-2575 the `initialize`/`initialized` handshake is removed; FastMCP's client will no longer consume those 2 pre-tool requests during connection setup. The test uses the magic number 7 (successful calls before hitting the 10-request window limit), derived from 10 - 3. If FastMCP's connection setup changes to 1 request (just `tools/list`), the 7 will silently drift to 9, causing the test to over-count capacity or pass/fail incorrectly.
+
+**Migration:** Replace the hardcoded budget with a value derived at test setup time (issue a no-op request, read the rate-limit counter) so the test self-adjusts when FastMCP's connection-setup request count changes.
+
+---
+
+### C10 -- OPPORTUNITY (low) -- No cache hints on static resources
+
+**File:** `src/math_mcp/resources.py`
+
+`math://functions`, `math://constants/{name}`, `math://catalog/tools`, `math://tutor/{topic}`, `math://formulas/{formula}` are effectively static content but expose no `ttlMs`/`cacheScope` metadata. The 2026-07-28 spec adds these optional fields to resource reads and `tools/list`, letting conformant clients avoid redundant round-trips.
+
+**Migration:** When FastMCP exposes an API for `ttlMs`/`cacheScope` on resource responses, annotate static resources with a generous TTL (e.g. 3600000 ms). Defer until FastMCP surfaces the API.
+
+---
+
+### C11 -- OPPORTUNITY (low) -- No W3C Trace Context propagation in middleware
+
+**File:** `src/math_mcp/server.py` (lines ~58-72, middleware stack)
+
+`StructuredLoggingMiddleware`, `ErrorHandlingMiddleware`, and `SlidingWindowRateLimitingMiddleware` do not read or propagate `traceparent`/`tracestate`/`baggage` from request `_meta`. The 2026-07-28 spec standardizes W3C Trace Context in `_meta` for distributed tracing, replacing the deprecated Logging feature as the forward observability path.
+
+**Migration:** When FastMCP exposes trace-context fields on the request context, thread `traceparent`/`tracestate` through the structured logging middleware and any future OpenTelemetry integration for cross-service correlation.
+
+---
+
+### C12 -- OPPORTUNITY (info) -- No Tasks extension for long-running visualization work
+
+**File:** `src/math_mcp/tools/visualization.py`
+
+Plot tools use `ctx.report_progress` for progress notifications during `asyncio.to_thread` offload. The new `io.modelcontextprotocol/tasks` extension supports poll-based async completion. For current sub-second matplotlib rendering this is not a gap, but it is a natural migration path if workloads grow.
+
+**Migration:** No action needed today. If rendering workloads grow (large datasets, high-resolution output), consider the Tasks extension for poll-based completion instead of blocking `report_progress` within a single request.
+
+---
+
+### C13 -- CLEAN (info) -- fastmcp upper-bound pin already in place
+
+**File:** `pyproject.toml` (line 24)
+
+`fastmcp>=3.2.4,<4.0.0` was the F01 fix from the 2026-07-27 audit. This limits exposure to an uncoordinated jump into FastMCP's stateless-core rework. No action required.
+
+---
+
+### C14 -- CLEAN (info) -- No Roots, Sampling, or Dynamic Client Registration usage
+
+No references to Roots, Sampling, or Dynamic Client Registration were found anywhere under `src/math_mcp/` or `docs/`. This server does not use any of the three deprecated-with-replacement features that carry migration burden. No action required.
+
+---
+
+### C15 -- CLEAN (info) -- No HTTP+SSE transport declared
+
+**Files:** `fastmcp.json`, `server.json`, `smithery.yaml`
+
+Transport is Streamable HTTP (`fastmcp.json` `deployment.transport: "http"`) and stdio. No SSE-specific transport code or configuration was found. The deprecated HTTP+SSE transport migration does not apply.
+
+---
+
+## Open Issues Cross-Reference
+
+| Issue | Title | Relation to This Audit |
+|---|---|---|
+| [#425](https://github.com/clouatre-labs/math-mcp-learning-server/issues/425) | fix(tools): migrate protocol logging notifications to Python logging | Created from this audit. Covers findings C01-C05. |
+| [#426](https://github.com/clouatre-labs/math-mcp-learning-server/issues/426) | test(http): replace test_http_ping with tools/list liveness check | Created from this audit. Covers finding C08. |
+| [#427](https://github.com/clouatre-labs/math-mcp-learning-server/issues/427) | test(rate-limit): remove hardcoded handshake request budget | Created from this audit. Covers finding C09. |
+| [#418](https://github.com/clouatre-labs/math-mcp-learning-server/issues/418) | feat(eval): AST-based expression validator | No relation to MCP 2026-07-28. Standalone defense-in-depth improvement for `eval.py`. |
+| [#416](https://github.com/clouatre-labs/math-mcp-learning-server/issues/416) | chore: add pyright config block and extras in CI | No relation. Typing hygiene fix. Relevant to all future work including any MCP migration. |
+| [#415](https://github.com/clouatre-labs/math-mcp-learning-server/issues/415) | test: fix coverage gate scope | No relation. Coverage measurement correctness. |
+| [#414](https://github.com/clouatre-labs/math-mcp-learning-server/issues/414) | ci: SHA256 verification for mcp-publisher binary and permissions | No relation. CI security hygiene. |
+| [#86](https://github.com/clouatre-labs/math-mcp-learning-server/issues/86) | Dependency Dashboard (Renovate) | Tangential: Renovate will surface the FastMCP version bump when it targets 2026-07-28 compliance. The `<4.0.0` ceiling pin will surface as a conflict to resolve manually, which is the intended behavior (C13). |
+
+Issues #425, #426, #427 were created from this audit. Issues #414-#418 are from the 2026-07-27 quality audit and remain valid and orthogonal. Addressing #416 (pyright config) and #418 (AST eval) is recommended before tackling any MCP migration work, as both improve the signal quality of type checking and security review during future changes.
+
+---
+
+## Summary
+
+*Table 1: Finding classification by count.*
+
+| Category | Count | Severity breakdown |
+|---|---|---|
+| BREAKING | 2 | 1 low (C08), 1 info (C09) |
+| DEPRECATED-IN-USE | 5 | 3 medium (C01-C03), 2 low (C04-C05) |
+| OPPORTUNITY | 3 | 2 low (C10-C11), 1 info (C12) |
+| CLEAN | 5 | 5 info (C06-C07, C13-C15) |
+
+**The server has no application-level implementation of any removed feature.** Breaking changes (ping removal, handshake removal, session removal, `logging/setLevel` removal) are fully delegated to FastMCP internals. The `<4.0.0` pin ensures the application is not silently upgraded into FastMCP's 2026-07-28 rework before it is validated.
+
+**The primary action area is the deprecated Logging feature (C01-C05).** All five `ctx.info` / `ctx.warning` / `ctx.error` usages in the five source files represent protocol-level `notifications/message` emission with no `_meta` opt-in gating, which is now a spec MUST-NOT violation. These do not break today (12-month deprecation window), but the fix is straightforward: replace with Python `logging` calls, which are already the established pattern in `server.py` and `eval.py`.
+
+**The two breaking findings (C08, C09) are both test-layer artifacts**, not server behavior gaps. They will surface as test failures when FastMCP drops `ping` and adjusts its handshake request count, not as runtime errors visible to production clients.
+
+## Recommended Action Order
+
+1. **C01-C05 (Logging migration) -- [#425](https://github.com/clouatre-labs/math-mcp-learning-server/issues/425)** -- Replace `ctx.info`/`ctx.warning`/`ctx.error` with Python `logging` across all five files. This resolves the MUST-NOT unconditional-emission conformance issue and eliminates the deprecated-in-use pattern before the removal clock runs down. One PR, straightforward find-and-replace with pattern already established in the codebase.
+
+2. **C08 (ping test) -- [#426](https://github.com/clouatre-labs/math-mcp-learning-server/issues/426)** -- Track FastMCP 3.x changelog. Delete `test_http_ping` when FastMCP drops `ping`; replace with a `tools/list` liveness call. Defer until FastMCP ships the change.
+
+3. **C09 (rate-limit magic number) -- [#427](https://github.com/clouatre-labs/math-mcp-learning-server/issues/427)** -- Refactor the rate-limit test budget to be self-measuring. Low urgency; no production impact.
+
+4. **C10-C12 (Opportunities)** -- Defer until FastMCP exposes the relevant APIs (`ttlMs`, trace-context fields). No SDK surface exists today.
+
+5. **C07 residual risk** -- Re-verify `ctx.get_state`/`set_state` semantics at next FastMCP major upgrade targeting 2026-07-28 stateless transport.


### PR DESCRIPTION
## Summary

Adds the MCP 2026-07-28 specification alignment audit for math-mcp-learning-server v0.12.2.

The 2026-07-28 spec is the largest MCP revision since launch. This audit covers all 15 findings
(2 breaking, 5 deprecated-in-use, 3 opportunities, 5 clean) identified against the codebase.

## Findings overview

| Category | Count | Notes |
|---|---|---|
| BREAKING | 2 | C08-C09, both test-layer only -- no production behavior gap |
| DEPRECATED-IN-USE | 5 | C01-C05, all `ctx.info`/`ctx.warning`/`ctx.error` calls |
| OPPORTUNITY | 3 | C10-C12, deferred until FastMCP SDK surfaces the APIs |
| CLEAN | 5 | C06-C07, C13-C15 -- no action required |

The server has no application-level implementation of any removed MCP feature. Breaking changes
are fully delegated to FastMCP internals, protected by the existing `<4.0.0` ceiling pin.

## Issues created from this audit

- Closes #425 -- fix(tools): migrate protocol logging notifications to Python logging (C01-C05)
- Closes #426 -- test(http): replace test_http_ping with tools/list liveness check (C08)
- Closes #427 -- test(rate-limit): remove hardcoded handshake request budget (C09)

## No production code changed

This PR adds exactly one file: `docs/audit/2026-08-01-mcp-spec-2026-07-28.md`
