### PR TITLE
fix(tools): migrate ctx logging notifications to stdlib logging (C01-C05)

### DIFF
--- a/src/math_mcp/resources.py
+++ b/src/math_mcp/resources.py
@@ -3,9 +3,12 @@ Resources and Prompts Sub-Server
 FastMCP sub-server for mathematical resources, constants, and prompt templates.
 """
 
+import logging
 import math
 
 from fastmcp import Context, FastMCP
+
+logger = logging.getLogger(__name__)
 
 # Create sub-server for resources and prompts
 resources_mcp = FastMCP(name="Resources and Prompts")
@@ -36,7 +39,7 @@ def get_math_constant(constant: str) -> str:
 @resources_mcp.resource("math://functions")
 async def list_available_functions(ctx: Context) -> str:
     """List all available mathematical functions with examples and syntax help."""
-    await ctx.info("Accessing function reference documentation")
+    logger.info("Accessing function reference documentation")
     return """# Available Mathematical Functions
 
 ## Basic Functions
@@ -75,7 +78,7 @@ async def list_available_functions(ctx: Context) -> str:
 @resources_mcp.resource("math://history")
 async def get_calculation_history(ctx: Context) -> str:
     """Get the history of calculations performed across sessions."""
-    await ctx.info("Accessing calculation history")
+    logger.info("Accessing calculation history")
     from math_mcp.persistence.workspace import _workspace_manager
 
     workspace_data = _workspace_manager._load_workspace()
@@ -107,7 +110,7 @@ async def get_workspace(ctx: Context) -> str:
     including all saved calculations, metadata, and statistics. The workspace
     survives server restarts and is accessible across different transport modes.
     """
-    await ctx.info("Accessing persistent workspace")
+    logger.info("Accessing persistent workspace")
     from math_mcp.persistence.workspace import _workspace_manager
 
     summary = _workspace_manager.get_workspace_summary()
@@ -125,7 +128,7 @@ async def get_workspace(ctx: Context) -> str:
 @resources_mcp.resource("math://catalog/tools")
 async def list_tools_catalog(ctx: Context) -> str:
     """Catalog of all available tools with category, description, and example."""
-    await ctx.info("Accessing tools catalog")
+    logger.info("Accessing tools catalog")
     catalog = [
         {
             "name": "calculate",
@@ -279,7 +282,7 @@ Make your explanation clear and educational, suitable for someone learning about
 @resources_mcp.resource("math://variables")
 async def list_variable_names(ctx: Context) -> str:
     """List all variable names saved in the workspace (lightweight alternative to math://workspace)."""
-    await ctx.info("Listing workspace variable names")
+    logger.info("Listing workspace variable names")
     from math_mcp.persistence.workspace import _workspace_manager
 
     result = _workspace_manager.list_variables()

--- a/src/math_mcp/tools/calculate.py
+++ b/src/math_mcp/tools/calculate.py
@@ -3,6 +3,7 @@ Calculate Tools Sub-Server
 FastMCP sub-server for mathematical calculations, statistics, and unit conversions.
 """
 
+import logging
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
@@ -20,6 +21,8 @@ from math_mcp.settings import (
     MAX_EXPRESSION_LENGTH,
     validated_tool,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class CalculationResult(BaseModel):
@@ -103,8 +106,7 @@ async def calc_expression(
     - "sqrt(16)" → 4.0
     - "sin(3.14159/2)" → 1.0
     """
-    if ctx:
-        await ctx.info(f"Calculating expression: {expression}")
+    logger.info(f"Calculating expression: {expression}")
 
     result = await evaluate_with_timeout(expression)
     difficulty = _classify_expression_difficulty(expression)
@@ -155,8 +157,7 @@ async def calc_statistics(
         statistics([1.0, 2.5, 3.0, 4.5, 5.0], "std_dev")  # Returns ~1.58
     """
     if operation not in ALLOWED_OPERATIONS:
-        if ctx:
-            await ctx.warning(f"Invalid operation requested: {operation}")
+        logger.warning(f"Invalid operation requested: {operation}")
         raise ValueError(
             f"Invalid operation: {operation}. Allowed: {', '.join(sorted(ALLOWED_OPERATIONS))}"
         )
@@ -164,14 +165,12 @@ async def calc_statistics(
     if ctx:
         await ctx.report_progress(0, 2, "Validating input")
 
-    if ctx:
-        await ctx.info(f"Performing {operation} on {len(numbers)} data points")
+    logger.info(f"Performing {operation} on {len(numbers)} data points")
 
     import statistics as stats
 
     if not numbers:
-        if ctx:
-            await ctx.warning("Cannot calculate statistics on empty list")
+        logger.warning("Cannot calculate statistics on empty list")
         raise ValueError("Cannot calculate statistics on empty list")
 
     if ctx:
@@ -256,10 +255,9 @@ async def calc_interest(
         compound_interest(10000, 0.05, 5)  # $10,000 at 5% for 5 years → $12,762.82
         compound_interest(5000, 0.03, 10, 12)  # $5,000 at 3% compounded monthly → $6,744.25
     """
-    if ctx:
-        await ctx.info(
-            f"Calculating compound interest: ${principal:,.2f} @ {rate * 100}% for {time} years"
-        )
+    logger.info(
+        f"Calculating compound interest: ${principal:,.2f} @ {rate * 100}% for {time} years"
+    )
 
     final_amount = principal * (1 + rate / compounds_per_year) ** (compounds_per_year * time)
     total_interest = final_amount - principal
@@ -322,8 +320,7 @@ async def calc_units(
         convert_units(5, "km", "mi", "length")  # 5 kilometers → 3.11 miles
         convert_units(150, "lb", "kg", "weight")  # 150 pounds → 68.04 kilograms
     """
-    if ctx:
-        await ctx.info(f"Converting {value} {from_unit} to {to_unit} ({unit_type})")
+    logger.info(f"Converting {value} {from_unit} to {to_unit} ({unit_type})")
 
     conversions = {
         "length": {
@@ -349,8 +346,7 @@ async def calc_units(
     else:
         conversion_table = conversions.get(unit_type)
         if not conversion_table:
-            if ctx:
-                await ctx.warning(f"Unknown unit type requested: {unit_type}")
+            logger.warning(f"Unknown unit type requested: {unit_type}")
             raise ValueError(
                 f"Unknown unit type '{unit_type}'. Available: length, weight, temperature"
             )
@@ -359,12 +355,10 @@ async def calc_units(
         to_factor = conversion_table.get(to_unit.lower())
 
         if from_factor is None:
-            if ctx:
-                await ctx.warning(f"Unknown {unit_type} unit: {from_unit}")
+            logger.warning(f"Unknown {unit_type} unit: {from_unit}")
             raise ValueError(f"Unknown {unit_type} unit '{from_unit}'")
         if to_factor is None:
-            if ctx:
-                await ctx.warning(f"Unknown {unit_type} unit: {to_unit}")
+            logger.warning(f"Unknown {unit_type} unit: {to_unit}")
             raise ValueError(f"Unknown {unit_type} unit '{to_unit}'")
 
         base_value = value * from_factor

--- a/src/math_mcp/tools/matrix.py
+++ b/src/math_mcp/tools/matrix.py
@@ -5,6 +5,7 @@ calculations using NumPy. All tools include input validation, error handling,
 and educational annotations.
 """
 
+import logging
 from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
@@ -12,6 +13,8 @@ from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field, SkipValidation
 
 from math_mcp.settings import MAX_ARRAY_SIZE, validated_tool
+
+logger = logging.getLogger(__name__)
 
 # Try importing numpy for matrix operations
 try:
@@ -164,8 +167,7 @@ async def matrix_multiply(
         matrix_multiply([[1, 2], [3, 4]], [[5, 6], [7, 8]])
         matrix_multiply([[1, 2, 3]], [[1], [2], [3]])
     """
-    if ctx:
-        await ctx.info("Performing matrix multiplication")
+    logger.info("Performing matrix multiplication")
 
     mat_a = _validate_matrix(matrix_a)
     mat_b = _validate_matrix(matrix_b)
@@ -219,8 +221,7 @@ async def matrix_transpose(
         matrix_transpose([[1, 2, 3], [4, 5, 6]])
         matrix_transpose([[1], [2], [3]])
     """
-    if ctx:
-        await ctx.info("Transposing matrix")
+    logger.info("Transposing matrix")
 
     mat = _validate_matrix(matrix)
     result = mat.T  # type: ignore
@@ -263,8 +264,7 @@ async def matrix_determinant(
         matrix_determinant([[1, 2], [3, 4]])
         matrix_determinant([[1, 0, 0], [0, 1, 0], [0, 0, 1]])  # Identity matrix
     """
-    if ctx:
-        await ctx.info("Calculating matrix determinant")
+    logger.info("Calculating matrix determinant")
 
     mat = _validate_matrix(matrix)
 
@@ -312,8 +312,7 @@ async def matrix_inverse(
         matrix_inverse([[1, 2], [3, 4]])
         matrix_inverse([[2, 0], [0, 2]])  # Diagonal matrix
     """
-    if ctx:
-        await ctx.info("Calculating matrix inverse")
+    logger.info("Calculating matrix inverse")
 
     if ctx:
         await ctx.report_progress(0, 3, "Validating matrix")
@@ -331,8 +330,7 @@ async def matrix_inverse(
 
     det = la.det(mat)  # type: ignore
     if abs(det) < 1e-10:
-        if ctx:
-            await ctx.warning("Matrix is singular (determinant near 0); inverse does not exist")
+        logger.warning("Matrix is singular (determinant near 0); inverse does not exist")
         return MatrixInverseResult(
             size=int(mat.shape[0]),
             success=False,
@@ -387,8 +385,7 @@ async def matrix_eigenvalues(
         matrix_eigenvalues([[4, 2], [1, 3]])
         matrix_eigenvalues([[3, 0, 0], [0, 5, 0], [0, 0, 7]])  # Diagonal matrix
     """
-    if ctx:
-        await ctx.info("Calculating matrix eigenvalues")
+    logger.info("Calculating matrix eigenvalues")
 
     if ctx:
         await ctx.report_progress(0, 2, "Validating matrix")
@@ -396,10 +393,7 @@ async def matrix_eigenvalues(
     mat = _validate_matrix(matrix)
 
     if mat.shape[0] != mat.shape[1]:
-        if ctx:
-            await ctx.warning(
-                f"Eigenvalues require square matrix; got {mat.shape[0]}x{mat.shape[1]}"
-            )
+        logger.warning(f"Eigenvalues require square matrix; got {mat.shape[0]}x{mat.shape[1]}")
         return MatrixEigenvaluesResult(
             size=int(mat.shape[0]),
             success=False,
@@ -416,10 +410,9 @@ async def matrix_eigenvalues(
     # Detect complex eigenvalues (imaginary part exceeds floating-point noise threshold)
     has_complex = any(abs(val.imag) > 1e-10 for val in eigenvalues)
     if has_complex:
-        if ctx:
-            await ctx.warning(
-                "Matrix has complex eigenvalues; imaginary parts truncated to real in eigenvalues field"
-            )
+        logger.warning(
+            "Matrix has complex eigenvalues; imaginary parts truncated to real in eigenvalues field"
+        )
 
     # Convert eigenvalues to list of floats (real parts only, for backward compat)
     eigenval_list = [float(val.real) for val in eigenvalues]  # type: ignore

--- a/src/math_mcp/tools/persistence.py
+++ b/src/math_mcp/tools/persistence.py
@@ -3,6 +3,7 @@ Persistence Tools Sub-Server
 FastMCP sub-server for saving and loading calculations from persistent workspace.
 """
 
+import logging
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
@@ -20,6 +21,8 @@ from math_mcp.settings import (
     validated_tool,
 )
 from math_mcp.tools._session import _get_or_create_session_id
+
+logger = logging.getLogger(__name__)
 
 
 class SaveCalculationResult(BaseModel):
@@ -94,8 +97,7 @@ async def workspace_save(
     """
     validate_variable_name(name)
 
-    if ctx:
-        await ctx.info(f"Saving calculation '{name}' = {result}")
+    logger.info(f"Saving calculation '{name}' = {result}")
 
     difficulty = _classify_expression_difficulty(expression)
     topic = _classify_expression_topic(expression)
@@ -147,15 +149,13 @@ async def workspace_load(
         load_variable("portfolio_return")  # Returns saved calculation
         load_variable("circle_area")       # Access across sessions
     """
-    if ctx:
-        await ctx.info(f"Loading variable '{name}'")
+    logger.info(f"Loading variable '{name}'")
     from math_mcp.persistence.workspace import _workspace_manager
 
     result_data = _workspace_manager.load_variable(name)
 
     if not result_data["success"]:
-        if ctx:
-            await ctx.warning(f"Variable '{name}' not found in workspace")
+        logger.warning(f"Variable '{name}' not found in workspace")
         return LoadVariableResult(
             success=False,
             name=name,

--- a/src/math_mcp/tools/visualization.py
+++ b/src/math_mcp/tools/visualization.py
@@ -4,6 +4,7 @@ Extracted from server.py as part of the monolith decomposition (#140c).
 Each tool generates PNG images using matplotlib and returns Image objects.
 """
 
+import logging
 import re
 from functools import wraps
 from typing import Annotated, Any
@@ -25,6 +26,8 @@ from math_mcp.settings import (
     MAX_STRING_PARAM_LENGTH,
     validated_tool,
 )
+
+logger = logging.getLogger(__name__)
 
 # --- Sub-server instance ---
 visualization_mcp = FastMCP("visualization-tools")
@@ -165,8 +168,7 @@ async def plot_function(
         plot_function("sin(x)", (-3.14, 3.14))
     """
 
-    if ctx:
-        await ctx.info(f"Plotting function: {expression} over range {x_range}")
+    logger.info(f"Plotting function: {expression} over range {x_range}")
 
     try:
         import numpy as np
@@ -184,15 +186,13 @@ async def plot_function(
         return Image(data=image_bytes, format="png")
 
     except ValueError as e:
-        if ctx:
-            await ctx.error(f"Plot function error: {e}")
+        logger.error(f"Plot function error: {e}")
         return VisualizationError(
             message=f"**Plot Error:** {str(e)}\n\nPlease check your expression and x_range values.",
             error_type="plot_error",
         )
     except Exception as e:
-        if ctx:
-            await ctx.error(f"Plot function unexpected error: {e}")
+        logger.error(f"Plot function unexpected error: {e}")
         return VisualizationError(
             message=f"**Unexpected Error:** {str(e)}",
             error_type="unexpected_error",
@@ -240,8 +240,7 @@ async def plot_histogram(  # noqa: C901
             error_type="validation_error",
         )
 
-    if ctx:
-        await ctx.info(f"Creating histogram with {len(data)} data points and {bins} bins")
+    logger.info(f"Creating histogram with {len(data)} data points and {bins} bins")
 
     try:
         if not data:
@@ -272,15 +271,13 @@ async def plot_histogram(  # noqa: C901
         return Image(data=image_bytes, format="png")
 
     except ValueError as e:
-        if ctx:
-            await ctx.error(f"Histogram error: {e}")
+        logger.error(f"Histogram error: {e}")
         return VisualizationError(
             message=f"**Histogram Error:** {str(e)}\n\nPlease check your data and parameters.",
             error_type="histogram_error",
         )
     except Exception as e:
-        if ctx:
-            await ctx.error(f"Histogram unexpected error: {e}")
+        logger.error(f"Histogram unexpected error: {e}")
         return VisualizationError(
             message=f"**Unexpected Error:** {str(e)}",
             error_type="unexpected_error",
@@ -339,8 +336,7 @@ async def plot_line_chart(
     """
 
     # Matplotlib is guaranteed to be available (decorator handles ImportError)
-    if ctx:
-        await ctx.info(f"Creating line chart with {len(x_data)} data points")
+    logger.info(f"Creating line chart with {len(x_data)} data points")
 
     try:
         image_bytes = visualization.create_line_chart(
@@ -419,8 +415,7 @@ async def plot_scatter(
     """
 
     # Matplotlib is guaranteed to be available (decorator handles ImportError)
-    if ctx:
-        await ctx.info(f"Creating scatter plot with {len(x_data)} data points")
+    logger.info(f"Creating scatter plot with {len(x_data)} data points")
 
     try:
         image_bytes = visualization.create_scatter_plot(
@@ -503,8 +498,7 @@ async def plot_box_plot(
         return err
 
     # Matplotlib is guaranteed to be available (decorator handles ImportError)
-    if ctx:
-        await ctx.info(f"Creating box plot with {len(data_groups)} groups")
+    logger.info(f"Creating box plot with {len(data_groups)} groups")
 
     try:
         image_bytes = visualization.create_box_plot(
@@ -577,8 +571,7 @@ async def plot_financial_line(
         )
 
     # Matplotlib is guaranteed to be available (decorator handles ImportError)
-    if ctx:
-        await ctx.info(f"Generating synthetic {trend} price data for {days} days")
+    logger.info(f"Generating synthetic {trend} price data for {days} days")
 
     try:
         # Stage 0: Start

--- a/tests/test_math_operations.py
+++ b/tests/test_math_operations.py
@@ -858,14 +858,15 @@ def test_ensure_workspace_directory_oserror():
 
 
 @pytest.mark.asyncio
-async def test_calculate_with_context():
+async def test_calculate_with_context(caplog):
     """calculate() logs info via context."""
-    from unittest.mock import AsyncMock, MagicMock
+    import logging
 
-    mock_ctx = AsyncMock()
-    result = await calc_expression("2 + 2", ctx=mock_ctx)
+    caplog.set_level(logging.INFO)
+    result = await calc_expression("2 + 2", ctx=None)
     assert result is not None
-    mock_ctx.info.assert_called_once()
+    assert any(r.levelno == logging.INFO for r in caplog.records)
+    assert any("Calculating expression" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -877,14 +878,15 @@ async def test_calculate_without_context():
 
 
 @pytest.mark.asyncio
-async def test_convert_units_with_context():
+async def test_convert_units_with_context(caplog):
     """convert_units() logs info via context."""
-    from unittest.mock import AsyncMock
+    import logging
 
-    mock_ctx = AsyncMock()
-    result = await calc_units(100.0, "m", "ft", "length", ctx=mock_ctx)
+    caplog.set_level(logging.INFO)
+    result = await calc_units(100.0, "m", "ft", "length", ctx=None)
     assert result is not None
-    mock_ctx.info.assert_called_once()
+    assert any(r.levelno == logging.INFO for r in caplog.records)
+    assert any("Converting" in r.message for r in caplog.records)
 
 
 # === RESOURCES.PY ===
@@ -923,16 +925,17 @@ async def test_statistics_with_progress_ctx() -> None:
 
 
 @pytest.mark.asyncio
-async def test_statistics_invalid_op_with_ctx() -> None:
+async def test_statistics_invalid_op_with_ctx(caplog) -> None:
     """statistics() covers ctx warning branch when operation is invalid."""
-    from unittest.mock import AsyncMock
+    import logging
 
     from math_mcp.tools.calculate import calc_statistics
 
-    mock_ctx = AsyncMock()
+    caplog.set_level(logging.WARNING)
     with pytest.raises(ValueError, match="Invalid operation"):
-        await calc_statistics.raw_function([1.0, 2.0], "invalid_op", mock_ctx)
-    mock_ctx.warning.assert_called()
+        await calc_statistics.raw_function([1.0, 2.0], "invalid_op", None)
+    assert any(r.levelno == logging.WARNING for r in caplog.records)
+    assert any("Invalid operation" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -7,6 +7,8 @@ package availability before running visualization tests. The noqa: F401 comments
 suppress unused import warnings as these imports are used for dependency checking.
 """
 
+import unittest.mock
+
 import pytest
 from fastmcp.utilities.types import Image
 
@@ -45,15 +47,13 @@ async def test_plot_function_basic_quadratic(mock_context):
 
     from math_mcp.tools.visualization import plot_function
 
-    result = await plot_function.raw_function("x**2", (-5.0, 5.0), 50, mock_context)
+    with unittest.mock.patch("math_mcp.tools.visualization.logger") as mock_logger:
+        result = await plot_function.raw_function("x**2", (-5.0, 5.0), 50, mock_context)
+        assert mock_logger.info.called
 
     assert isinstance(result, Image)
     assert result.data is not None
     assert len(result.data) > 0
-
-    # Verify context logging
-    assert len(mock_context.info_logs) > 0
-    assert "Plotting function" in mock_context.info_logs[0]
 
 
 @pytest.mark.asyncio
@@ -185,16 +185,13 @@ async def test_plot_histogram_basic(mock_context):
     from math_mcp.tools.visualization import plot_histogram
 
     data = [1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 5.0]
-    result = await plot_histogram.raw_function(data, 5, "Test Distribution", mock_context)
+    with unittest.mock.patch("math_mcp.tools.visualization.logger") as mock_logger:
+        result = await plot_histogram.raw_function(data, 5, "Test Distribution", mock_context)
+        assert mock_logger.info.called
 
     assert isinstance(result, Image)
     assert result.data is not None
     assert len(result.data) > 0
-
-    # Verify context logging
-    assert len(mock_context.info_logs) > 0
-    assert "Creating histogram" in mock_context.info_logs[0]
-    assert "9 data points" in mock_context.info_logs[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Migrate ctx.info, ctx.warning, and ctx.error notifications to stdlib logging across the five affected source modules for MCP 2026-07-28 compliance. Update tests to verify logging with caplog and logger patching.

Closes #425

## Files changed
- src/math_mcp/resources.py
- src/math_mcp/tools/calculate.py
- src/math_mcp/tools/matrix.py
- src/math_mcp/tools/persistence.py
- src/math_mcp/tools/visualization.py
- tests/test_math_operations.py
- tests/test_visualization.py

## Test strategy
- caplog assertions verify INFO and WARNING records in test_math_operations.py.
- unittest.mock.patch assertions verify module logger calls in test_visualization.py.
- 201 tests pass.

## Acceptance criteria verification
- All five source files define module loggers using stdlib logging.
- ctx.report_progress guards are preserved.
- Resource ctx: Context signatures are unchanged.
- Visualization error paths log and return VisualizationError without raising.
- No dependencies were added.
- Ruff and Pyright pass.
- Security scan is clean.
