### PR TITLE
test(http-rate-limit): replace ping with liveness check and measure rate-limit budget (C08, C09)

### DIFF
--- a/tests/test_http_integration.py
+++ b/tests/test_http_integration.py
@@ -12,10 +12,10 @@ from fastmcp import Client
 from fastmcp.exceptions import ToolError
 
 
-async def test_http_ping(http_client: Client) -> None:
-    """Test server responds to ping over HTTP."""
-    result = await http_client.ping()
-    assert result is True
+async def test_http_liveness(http_client: Client) -> None:
+    """Test server liveness over HTTP by listing tools."""
+    tools = await http_client.list_tools()
+    assert len(tools) > 0
 
 
 async def test_http_calculate_basic(http_client: Client) -> None:

--- a/tests/test_math_operations.py
+++ b/tests/test_math_operations.py
@@ -347,15 +347,26 @@ async def test_rate_limit_enforcement():
     # Create test server with limit high enough for test setup + tool calls
     test_mcp = FastMCP("test-rate-limit")
     test_mcp.add_middleware(ErrorHandlingMiddleware())
-    test_mcp.add_middleware(SlidingWindowRateLimitingMiddleware(max_requests=10, window_minutes=1))
+    rate_limiter = SlidingWindowRateLimitingMiddleware(max_requests=10, window_minutes=1)
+    test_mcp.add_middleware(rate_limiter)
 
     @test_mcp.tool()
     def test_tool() -> str:
         return "success"
 
     async with Client(transport=test_mcp) as client:
-        # Make 7 successful tool calls (Client init consumes 3 of 10 requests: initialize, notifications/initialized, tools/list)
-        for _ in range(7):
+        # Make one no-op call to measure the pre-tool request count from middleware state
+        await client.list_tools()
+
+        # Read the measured overhead from the middleware limiter state.
+        # rate_limiter.limiters is an internal attribute; the same access pattern is
+        # already used by the reset_rate_limit fixture in conftest.py (see line 63).
+        max_requests = rate_limiter.max_requests
+        used = len(rate_limiter.limiters["global"].requests)
+        remaining = max_requests - used
+
+        # Make all remaining calls successfully, filling the window to max_requests
+        for _ in range(remaining):
             result = await client.call_tool("test_tool", {})
             assert result.content[0].text == "success"
 

--- a/uv.lock
+++ b/uv.lock
@@ -698,7 +698,7 @@ wheels = [
 
 [[package]]
 name = "math-mcp-learning-server"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
Fix audit findings C08 and C09 by replacing the removed HTTP ping test with an HTTP liveness check and measuring the rate-limit request budget dynamically.

## Changes
tests/test_http_integration.py
tests/test_math_operations.py
uv.lock

## Test plan
- [ ] Tests pass (see 03-build.json test_results)
- [ ] Linter clean
- [ ] Security scan clean (see 04-validation.json security_summary)

Closes #426
Closes #427
