### PR TITLE
docs(audit): mark MCP 2026-07-28 action items resolved

### DIFF
--- a/docs/audit/2026-08-01-mcp-spec-2026-07-28.md
+++ b/docs/audit/2026-08-01-mcp-spec-2026-07-28.md
@@ -229,9 +229,9 @@ Transport is Streamable HTTP (`fastmcp.json` `deployment.transport: "http"`) and
 
 | Issue | Title | Relation to This Audit |
 |---|---|---|
-| [#425](https://github.com/clouatre-labs/math-mcp-learning-server/issues/425) | fix(tools): migrate protocol logging notifications to Python logging | Created from this audit. Covers findings C01-C05. |
-| [#426](https://github.com/clouatre-labs/math-mcp-learning-server/issues/426) | test(http): replace test_http_ping with tools/list liveness check | Created from this audit. Covers finding C08. |
-| [#427](https://github.com/clouatre-labs/math-mcp-learning-server/issues/427) | test(rate-limit): remove hardcoded handshake request budget | Created from this audit. Covers finding C09. |
+| [#425](https://github.com/clouatre-labs/math-mcp-learning-server/issues/425) | fix(tools): migrate protocol logging notifications to Python logging | Created from this audit. Covers findings C01-C05. **Resolved -- merged in [#429](https://github.com/clouatre-labs/math-mcp-learning-server/pull/429) (2026-08-01).** |
+| [#426](https://github.com/clouatre-labs/math-mcp-learning-server/issues/426) | test(http): replace test_http_ping with tools/list liveness check | Created from this audit. Covers finding C08. **Resolved -- merged in [#430](https://github.com/clouatre-labs/math-mcp-learning-server/pull/430) (2026-08-01).** |
+| [#427](https://github.com/clouatre-labs/math-mcp-learning-server/issues/427) | test(rate-limit): remove hardcoded handshake request budget | Created from this audit. Covers finding C09. **Resolved -- merged in [#430](https://github.com/clouatre-labs/math-mcp-learning-server/pull/430) (2026-08-01).** |
 | [#418](https://github.com/clouatre-labs/math-mcp-learning-server/issues/418) | feat(eval): AST-based expression validator | No relation to MCP 2026-07-28. Standalone defense-in-depth improvement for `eval.py`. |
 | [#416](https://github.com/clouatre-labs/math-mcp-learning-server/issues/416) | chore: add pyright config block and extras in CI | No relation. Typing hygiene fix. Relevant to all future work including any MCP migration. |
 | [#415](https://github.com/clouatre-labs/math-mcp-learning-server/issues/415) | test: fix coverage gate scope | No relation. Coverage measurement correctness. |
@@ -253,6 +253,8 @@ Issues #425, #426, #427 were created from this audit. Issues #414-#418 are from 
 | OPPORTUNITY | 3 | 2 low (C10-C11), 1 info (C12) |
 | CLEAN | 5 | 5 info (C06-C07, C13-C15) |
 
+**Update (2026-08-01):** All audit-created action items are resolved. C01-C05 merged in #429; C08 and C09 merged in #430. The server is now fully aligned with MCP 2026-07-28 at the application layer. Remaining items (C10-C12 opportunities, C07 residual risk) are deferred pending FastMCP SDK surface changes.
+
 **The server has no application-level implementation of any removed feature.** Breaking changes (ping removal, handshake removal, session removal, `logging/setLevel` removal) are fully delegated to FastMCP internals. The `<4.0.0` pin ensures the application is not silently upgraded into FastMCP's 2026-07-28 rework before it is validated.
 
 **The primary action area is the deprecated Logging feature (C01-C05).** All five `ctx.info` / `ctx.warning` / `ctx.error` usages in the five source files represent protocol-level `notifications/message` emission with no `_meta` opt-in gating, which is now a spec MUST-NOT violation. These do not break today (12-month deprecation window), but the fix is straightforward: replace with Python `logging` calls, which are already the established pattern in `server.py` and `eval.py`.
@@ -261,11 +263,11 @@ Issues #425, #426, #427 were created from this audit. Issues #414-#418 are from 
 
 ## Recommended Action Order
 
-1. **C01-C05 (Logging migration) -- [#425](https://github.com/clouatre-labs/math-mcp-learning-server/issues/425)** -- Replace `ctx.info`/`ctx.warning`/`ctx.error` with Python `logging` across all five files. This resolves the MUST-NOT unconditional-emission conformance issue and eliminates the deprecated-in-use pattern before the removal clock runs down. One PR, straightforward find-and-replace with pattern already established in the codebase.
+1. **C01-C05 (Logging migration) -- [#425](https://github.com/clouatre-labs/math-mcp-learning-server/issues/425)** -- Replace `ctx.info`/`ctx.warning`/`ctx.error` with Python `logging` across all five files. This resolves the MUST-NOT unconditional-emission conformance issue and eliminates the deprecated-in-use pattern before the removal clock runs down. One PR, straightforward find-and-replace with pattern already established in the codebase. **DONE -- [#429](https://github.com/clouatre-labs/math-mcp-learning-server/pull/429).**
 
-2. **C08 (ping test) -- [#426](https://github.com/clouatre-labs/math-mcp-learning-server/issues/426)** -- Track FastMCP 3.x changelog. Delete `test_http_ping` when FastMCP drops `ping`; replace with a `tools/list` liveness call. Defer until FastMCP ships the change.
+2. **C08 (ping test) -- [#426](https://github.com/clouatre-labs/math-mcp-learning-server/issues/426)** -- Track FastMCP 3.x changelog. Delete `test_http_ping` when FastMCP drops `ping`; replace with a `tools/list` liveness call. Defer until FastMCP ships the change. **DONE -- [#430](https://github.com/clouatre-labs/math-mcp-learning-server/pull/430).**
 
-3. **C09 (rate-limit magic number) -- [#427](https://github.com/clouatre-labs/math-mcp-learning-server/issues/427)** -- Refactor the rate-limit test budget to be self-measuring. Low urgency; no production impact.
+3. **C09 (rate-limit magic number) -- [#427](https://github.com/clouatre-labs/math-mcp-learning-server/issues/427)** -- Refactor the rate-limit test budget to be self-measuring. Low urgency; no production impact. **DONE -- [#430](https://github.com/clouatre-labs/math-mcp-learning-server/pull/430).**
 
 4. **C10-C12 (Opportunities)** -- Defer until FastMCP exposes the relevant APIs (`ttlMs`, trace-context fields). No SDK surface exists today.
 


### PR DESCRIPTION
## Summary

Marks all action items from the MCP 2026-07-28 audit as resolved.

## Changes

- Cross-reference table: annotate #425, #426, #427 as resolved with links to #429 and #430
- Recommended Action Order: append DONE markers to items 1-3
- Summary section: add completion dateline noting full application-layer alignment

## No logic changes

Docs-only. No source, test, or config files touched.
