### PR TITLE
chore(ci): add pyright config block and typecheck job with plotting/scientific extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,26 @@ jobs:
     - name: Run tests with coverage
       run: uv run pytest tests/ -v --cov=math_mcp --cov-branch --cov-report=term-missing --cov-fail-under=90
 
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-24.04-arm
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install dependencies
+        run: uv sync --extra plotting --extra scientific --extra dev
+      - name: Run pyright
+        run: uv run pyright src/
+
   test-http-integration:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04-arm
@@ -174,7 +194,7 @@ jobs:
     name: CI Result
     runs-on: ubuntu-24.04-arm
     if: always()
-    needs: [lint, security, test, test-http-integration, zizmor, commitlint]
+    needs: [lint, security, test, typecheck, test-http-integration, zizmor, commitlint]
     permissions: {}
     steps:
       - name: Verify all jobs passed or were skipped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,8 @@ exclude_lines = [
 dev = [
     "pytest>=9.0.3",
 ]
+
+[tool.pyright]
+pythonVersion = "3.14"
+typeCheckingMode = "standard"
+reportMissingImports = true


### PR DESCRIPTION
## Summary

Audit 2026-07-27 finding F04.

**F04 (Medium)** -- No `[tool.pyright]` section existed in `pyproject.toml` and no typecheck job in CI. Pyright ran in default `basic` mode with no explicit Python version. Without `plotting` and `scientific` extras installed, `numpy` and `matplotlib` imports would fail stub resolution silently.

Changes:
- `pyproject.toml`: added `[tool.pyright]` with `pythonVersion = "3.14"`, `typeCheckingMode = "standard"`, `reportMissingImports = true`. No `venvPath`/`venv` (auto-discovered by uv sync).
- `ci.yml`: added dedicated `typecheck` job gated by `needs.changes.outputs.code`, installs `plotting + scientific + dev` extras before running `uv run pyright src/`. Added to `ci-result` needs list.

## Verification

```bash
uv sync --extra plotting --extra scientific --extra dev
uv run pyright src/
```

Expected: 0 errors, 0 warnings.

## Acceptance criteria

- [x] `pyproject.toml` contains `[tool.pyright]` with explicit `pythonVersion` and `typeCheckingMode`
- [x] `uv run pyright src/` (with plotting/scientific extras installed) reports zero errors
- [x] CI `typecheck` job installs extras before running pyright

Closes #416
