### PR TITLE
docs: add ADR-008 index, document AST eval layer, update CI job list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
     name: CI Result
     runs-on: ubuntu-24.04-arm
     if: always()
-    needs: [lint, security, test, typecheck, test-http-integration, zizmor, commitlint]
+needs: [lint, security, test, typecheck, test-http-integration, zizmor, commitlint]
     permissions: {}
     steps:
       - name: Verify all jobs passed or were skipped

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
     name: CI Result
     runs-on: ubuntu-24.04-arm
     if: always()
-needs: [lint, security, test, typecheck, test-http-integration, zizmor, commitlint]
+    needs: [lint, security, test, typecheck, test-http-integration, zizmor, commitlint]
     permissions: {}
     steps:
       - name: Verify all jobs passed or were skipped

--- a/ASSURANCE.md
+++ b/ASSURANCE.md
@@ -21,7 +21,7 @@ The server makes no outbound calls beyond FastMCP Cloud infrastructure. It holds
 
 The primary attack surfaces are:
 
-1. **eval() injection**: The `calculate` tool accepts math expressions evaluated with `eval()`. This is mitigated by a strict character and function allowlist in `eval.py` -- only math module functions and `abs` are permitted; all other identifiers and characters are rejected before evaluation.
+1. **eval() injection**: The `calculate` tool accepts math expressions evaluated with `eval()`. This is mitigated by a three-layer defense-in-depth model (see [ADR-001](docs/adr/001-eval-sandbox.md)): character/pattern blocklist, restricted globals (`math` + `abs` only), and an AST NodeVisitor allowlist (`_ASTValidator`) that rejects non-whitelisted AST node types before evaluation.
 
 2. **Workspace path traversal**: The `persistence` tools write and read files in a workspace directory. This is mitigated by path restriction in `storage.py`, which rejects any path that escapes the workspace root.
 
@@ -33,7 +33,7 @@ The primary attack surfaces are:
 
 | Weakness | Status |
 |----------|--------|
-| Injection (eval) | Mitigated -- character and function allowlist in eval.py; no arbitrary code execution |
+| Injection (eval) | Mitigated -- three-layer defense (character blocklist, restricted globals, AST NodeVisitor allowlist); no arbitrary code execution |
 | Path traversal | Mitigated -- workspace path restriction in storage.py rejects escaping paths |
 | Supply chain | Mitigated -- SLSA provenance attestation, pip-audit CVE scanning, SHA-pinned Actions, Renovate |
 | Secret leakage | Mitigated -- gitleaks secret scanning runs on every PR as a required CI check |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,7 @@ All pull requests run automated checks in parallel:
 - **lint** - Ruff code quality and formatting checks
 - **security** - gitleaks secret scanning and pip-audit CVE scanning
 - **test** - pytest functionality validation on Python 3.14 with >=90% coverage
+- **typecheck** - pyright static type checking
 - **zizmor** - GitHub Actions workflow security scanning
 - **commitlint** - Conventional commit message validation
 - **reuse** - SPDX license header compliance

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -95,10 +95,11 @@ Automated dependency updates via Renovate, including GitHub Actions pins.
 This project implements several security measures:
 
 ### Safe Expression Evaluation
-- Restricted `eval()` with whitelisted functions only
-- No access to dangerous built-ins or imports
+- Three-layer defense-in-depth model (see [ADR-001](docs/adr/001-eval-sandbox.md)):
+  - **Layer 1 (AST allowlist):** `_ASTValidator` (ast.NodeVisitor subclass) rejects non-whitelisted AST node types before evaluation
+  - **Layer 2 (Character whitelist + regex):** `_check_expression_security` rejects dangerous patterns (`import`, `exec`, `__`, `eval`, `open`, `file`) and invalid characters
+  - **Layer 3 (Restricted globals + timeout):** `_eval_in_restricted_scope` limits `eval()` to `math` module + `abs` only; 5-second execution timeout via `asyncio.wait_for`
 - Security logging for suspicious attempts
-- Controlled execution environment
 
 ### Input Validation
 - All tool inputs validated with Pydantic models
@@ -120,8 +121,9 @@ This project implements several security measures:
 A security review of this project was conducted in March 2026.
 
 **Scope:**
-- `src/math_mcp/eval.py`: restricted `eval()` implementation -- character whitelist,
-  dangerous-pattern blocklist, globals locked to `{abs, math}` only
+- `src/math_mcp/eval.py`: restricted `eval()` implementation -- three-layer defense:
+  AST NodeVisitor allowlist (`_ASTValidator`), character whitelist and dangerous-pattern
+  blocklist, globals locked to `{abs, math}` only
 - Input validation: Pydantic `validate_call` on all tool inputs
 - Workspace path restriction in `src/math_mcp/persistence/`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,6 +113,7 @@ FastMCP's `@mcp.prompt()` decorator registers reusable prompt templates that Cla
 | [ADR-005](adr/005-pydantic-validation.md) | Pydantic + @validated_tool for Input Validation | Accepted |
 | [ADR-006](adr/006-matplotlib-agg.md) | Matplotlib + Agg Backend for Visualization | Accepted |
 | [ADR-007](adr/007-json-workspace-persistence.md) | JSON Files for Workspace Persistence | Accepted |
+| [ADR-008](adr/008-annotation-quality-tests.md) | Annotation Quality Enforcement via Introspection Tests | Accepted |
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary
Housekeeping documentation updates keep the project index, security assurance language, and contributor CI documentation aligned with recent PRs #429-#435. The changes document the three-layer AST-based eval defense, index ADR-008, and list the typecheck CI job. No issue is being closed.

## Changes
- `docs/ARCHITECTURE.md`: Add ADR-008 to the architecture decision index.
- `SECURITY.md`: Document the AST NodeVisitor eval defense layer and three-layer model.
- `ASSURANCE.md`: Update eval mitigation assurance language and cite ADR-001.
- `CONTRIBUTING.md`: Add the typecheck job to the CI job list.

## Test plan
- [ ] Tests pass (documentation-only change; see 03-build.json test_results)
- [x] Linter clean (Ruff check and format check)
- [x] Security scan clean (see 04-validation.json security_summary)

Closes no issue; this is a housekeeping PR.