### PR TITLE
chore(release): bump version to 0.12.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.12.2"
+version = "0.12.3"
 description = "Educational MCP server for math operations, statistics, visualization, and persistent workspaces. Built with FastMCP."
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
Bumps `version` in `pyproject.toml` from `0.12.2` to `0.12.3`.

Patch release tagging the recent batch of security, CI, documentation, and test commits since v0.12.2.
