### PR TITLE
chore(aptu): standardize aptu.yml to canonical openrouter config

### DIFF
--- a/.github/aptu.yml
+++ b/.github/aptu.yml
@@ -4,8 +4,7 @@ triage:
 review:
   enabled: true
   instructions-file: .github/instructions/pr-review.md
-
 ai:
   provider: openrouter
-  model: google/gemma-4-26b-a4b-it:free
+  model: google/gemma-4-26b-a4b-it
   api-key-secret: OPENROUTER_API_KEY


### PR DESCRIPTION
Standardize `.github/aptu.yml` to canonical openrouter config.

Sets provider, model, and api-key-secret uniformly across all clouatre-labs repos.