### PR TITLE
ci: fix Scorecard ARM64 incompatibility, tighten zizmor gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
         with:
           advanced-security: false
           annotations: true
-          min-severity: high
+          min-severity: medium
           token: ${{ secrets.GITHUB_TOKEN }}
 
   poutine:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
       contents: read
     env:
       # mcp-publisher is an external tool; update this pin when bumping the tool version
-      MCP_PUBLISHER_VERSION: v1.8.0
+      MCP_PUBLISHER_VERSION: v1.8.1
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,9 +17,10 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     permissions:
-      id-token: write
       security-events: write
       contents: read
+    env:
+      SCORECARD_VERSION: v5.5.0
 
     steps:
       - name: Checkout repository
@@ -28,14 +29,38 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Download Scorecard CLI
+        run: |
+          gh release download "${SCORECARD_VERSION}" \
+            --repo ossf/scorecard \
+            --pattern 'scorecard_*_linux_arm64.tar.gz' \
+            --pattern 'scorecard_checksums.txt' \
+            --dir .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify Scorecard CLI checksum
+        run: |
+          grep '_linux_arm64.tar.gz$' scorecard_checksums.txt | sha256sum -c -
+
+      - name: Extract Scorecard CLI
+        run: tar -xzf scorecard_*_linux_arm64.tar.gz
+
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
+        run: |
+          ENABLE_SARIF=1 ./scorecard \
+            --repo=github.com/clouatre-labs/math-mcp-learning-server \
+            --format=sarif \
+            --show-details > results.sarif
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload results to Security tab
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload results artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file


### PR DESCRIPTION
## Summary

- Fix `scorecard.yml`: `ossf/scorecard-action:v2.4.4` ships an amd64-only docker image and has failed **every scheduled run since 2026-06-15** on our `ubuntu-24.04-arm` fleet (`exec /scorecard-action: exec format error`). Upstream `ossf/scorecard-action#1697` is still open on the latest release. Replaced with the checksum-verified `linux_arm64` scorecard CLI binary (v5.5.0) + `github/codeql-action/upload-sarif`, matching the fix already shipped in `clouatre-labs/aptu-coder#1399`.
- Raise `ci.yml`'s `zizmor` gate from `min-severity: high` to `medium` — verified locally this surfaces zero new findings against the current workflow set, so it's a free coverage improvement.
- Bump `MCP_PUBLISHER_VERSION` in `release.yml` from `v1.8.0` to `v1.8.1` (latest), per the workflow's own comment instructing manual bumps.

Every other workflow in this repo is already on `ubuntu-24.04-arm`; this was the only ARM64 gap found in a full CI audit. All other pinned actions are already at true-latest (verified via each repo's `releases/latest`, not the `gh release list` default sort, which can mis-rank repos with maintained older major-version branches).

## Scorecard publish tradeoff

`ossf/scorecard-action`'s `publish_results` flow signs results via cosign/Fulcio/Rekor and POSTs to `api.scorecard.dev` from inside the action's Go binary (`internal/scorecard`, `signing/signing.go`) — there's no equivalent flag on the standalone `scorecard` CLI. This repo currently has a published score (7.5, frozen since 2026-05-18, the last run before the ARM64 breakage started). Going full ARM64-only means that score will stop updating going forward.

Confirmed before making this tradeoff:
- No README badge or CI gate depends on the live score — it's referenced only as a text bullet in the features list.
- `CI Result` remains the sole required status check on the `Protect main branch` ruleset; Scorecard isn't required.

## Test plan

- [x] `scorecard.yml` no longer uses `ossf/scorecard-action`; runs the checksum-verified `linux_arm64` scorecard CLI on `ubuntu-24.04-arm`
- [x] SARIF uploaded via `github/codeql-action/upload-sarif`, correctly pinned to the commit SHA the `v4.37.7` tag actually dereferences to (not the annotated tag object SHA — caught and fixed after zizmor's `ref-version-mismatch` audit flagged the initial mispin)
- [x] `zizmor --min-severity medium` passes locally against all changed workflows with zero findings
- [x] `id-token: write` dropped from the Scorecard job's permissions (no longer needed without the cosign/Fulcio publish flow)
- [ ] `scorecard.yml` scheduled/dispatch run succeeds on ARM64 post-merge (verify after merge — no `exec format error`, SARIF appears in the Security tab)
