### PR TITLE
ci: restore scorecard.dev publishing via monthly amd64 exception job

### DIFF
--- a/.github/workflows/scorecard-publish.yml
+++ b/.github/workflows/scorecard-publish.yml
@@ -1,0 +1,43 @@
+name: Scorecard Publish
+
+# Single documented exception to the repo's ARM64-only runner policy.
+# ossf/scorecard-action's docker image has no arm64 build (ossf/scorecard-action#1697,
+# open), and the OIDC/cosign/Fulcio publish flow that updates the public score at
+# scorecard.dev is implemented inside that action's binary with no CLI equivalent, so
+# it can't be reproduced by the native scorecard CLI used in scorecard.yml. Scoped to a
+# monthly cron to minimize non-ARM runner usage; scorecard.yml still runs the actual
+# security analysis weekly on ubuntu-24.04-arm and uploads SARIF to the Security tab.
+
+on:
+  schedule:
+    - cron: "30 1 1 * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish score to scorecard.dev
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      id-token: write # required for cosign/Fulcio OIDC signing of the published result
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run Scorecard analysis and publish
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true


### PR DESCRIPTION
## Summary

Follow-up to #460. That PR moved `scorecard.yml` to a native ARM64 CLI, which fixed the ARM64 breakage but dropped `publish_results` — the flow that keeps the public score at scorecard.dev updated. That flow (cosign/Fulcio/Rekor signing, POST to `api.scorecard.dev`) is implemented inside `scorecard-action`'s Go binary with no CLI equivalent, and the action's docker image has no arm64 build (`ossf/scorecard-action#1697`, still open).

Adds `.github/workflows/scorecard-publish.yml`: a single, explicitly-documented exception to the repo's ARM64-only runner policy — `ossf/scorecard-action` on a standard `ubuntu-24.04` runner, monthly (`cron: "30 1 1 * *"`), whose only job is refreshing the published score. `scorecard.yml` is unchanged and keeps running the real analysis weekly on `ubuntu-24.04-arm`, uploading SARIF to the Security tab.

Cadence: GitHub Actions cron has no native "every N weeks" interval, so a true bi-weekly cycle isn't directly expressible — monthly was chosen to keep the non-ARM runner usage to the minimum needed to avoid the score going permanently stale.

## Test plan

- [x] `zizmor --min-severity medium` passes locally against all workflows including the new file
- [x] New job's permissions scoped to only `id-token: write` (required for cosign/Fulcio OIDC signing) and `contents: read` — no `security-events: write`, since this job doesn't upload SARIF (that stays in `scorecard.yml`)
- [ ] Manually dispatch `scorecard-publish.yml` after merge to confirm the score at scorecard.dev updates (verify post-merge — first scheduled run isn't until the 1st of next month)
