### PR TITLE
ci: add scheduled security audit, fix typecheck gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/scheduled-security-audit.yml
+++ b/.github/workflows/scheduled-security-audit.yml
@@ -26,7 +26,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -44,8 +45,10 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           advanced-security: false
           annotations: true
@@ -59,7 +62,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: boostsecurityio/poutine-action@e240ebd3eff8b2db5a8e5f6b28f58739d7db2247 # v1.1.4
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run poutine
+        uses: boostsecurityio/poutine-action@e240ebd3eff8b2db5a8e5f6b28f58739d7db2247 # v1.1.4
         with:
           action: analyze_local

--- a/.github/workflows/scheduled-security-audit.yml
+++ b/.github/workflows/scheduled-security-audit.yml
@@ -1,0 +1,65 @@
+name: Scheduled Security Audit
+
+# CVE data and Actions security advisories change independent of code commits.
+# ci.yml's pip-audit/zizmor/poutine jobs are gated behind a path-filter (only run
+# when src/**, tests/**, pyproject.toml, uv.lock, or .github/workflows/** change in
+# a PR), so a dependency or workflow could go newly vulnerable and stay unvetted
+# for weeks if nobody touches those paths. This workflow re-runs the same three
+# checks on a weekly schedule, independent of any diff.
+
+on:
+  schedule:
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  pip-audit:
+    name: CVE scan
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Scan dependencies for CVEs
+        run: uv tool run pip-audit
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          annotations: true
+          min-severity: medium
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  poutine:
+    name: Workflow Audit
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: boostsecurityio/poutine-action@e240ebd3eff8b2db5a8e5f6b28f58739d7db2247 # v1.1.4
+        with:
+          action: analyze_local


### PR DESCRIPTION
## Summary

Follow-up to the scorecard scheduling work in #461. Two independent fixes:

- **New scheduled workflow** (`scheduled-security-audit.yml`): `pip-audit` (CVE scan), `zizmor`, and `poutine` currently only run in `ci.yml` behind the `changes` job's path-filter (`src/**`, `tests/**`, `pyproject.toml`, `uv.lock`, `.github/workflows/**`). CVE data and Actions security advisories change independent of code commits, so if nobody touches those paths for a while, a dependency or a workflow can go newly vulnerable and stay unvetted. This adds a weekly scheduled workflow (`workflow_dispatch` too) that re-runs the same three checks unconditionally, mirroring the scoped-exception pattern `scorecard-publish.yml` already established. `ci.yml`'s own triggers and gating are untouched — this is a fully separate workflow, not an added `schedule:` on `ci.yml` (which would have cascaded to re-running lint/test/security on every tick, since those jobs share the same `|| github.event_name != 'pull_request'` gate).
- **Bug fix in `ci.yml`**: `typecheck`'s `if` was missing the `|| github.event_name != 'pull_request'` clause present on `lint`/`test`/`security`/`zizmor`/`poutine`. On a push to `main` with no code changes, those jobs still ran but `typecheck` silently skipped.

## Test plan

- [x] `zizmor --min-severity medium` passes locally against all workflows including the new file
- [x] `gitleaks` pre-commit hook passes
- [ ] Manually dispatch `scheduled-security-audit.yml` after merge to confirm all three jobs run clean
