### PR TITLE
fix(ci): drop conflicting annotations input from scheduled zizmor step

### DIFF
--- a/.github/workflows/scheduled-security-audit.yml
+++ b/.github/workflows/scheduled-security-audit.yml
@@ -52,7 +52,6 @@ jobs:
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           advanced-security: true
-          annotations: true
           min-severity: medium
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Follow-up to #463, which fixed the same `advanced-security: true` / `annotations: true` mutual-exclusivity conflict in `ci.yml`'s `zizmor` step but missed the identical config in `scheduled-security-audit.yml`. That workflow only triggers on `schedule`/`workflow_dispatch`, so it never runs as a PR check and #463's CI never exercised it — the next Monday 02:00 UTC run would have failed with zizmor-action's "mutually exclusive options" error.

- Drop `annotations: true` from the scheduled workflow's `zizmor` step, matching the `ci.yml` fix.

## Test plan

- [x] `zizmor --min-severity medium .github/workflows/` — clean, no findings
- [ ] Manually dispatch `scheduled-security-audit.yml` to confirm the `zizmor` job completes without the mutual-exclusivity error
