### PR TITLE
fix(ci): add continue-on-error to SARIF uploads for private repo compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,7 @@ jobs:
       - uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif
+        continue-on-error: true
 
   commitlint:
     name: commitlint

--- a/.github/workflows/scheduled-security-audit.yml
+++ b/.github/workflows/scheduled-security-audit.yml
@@ -71,3 +71,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif
+        continue-on-error: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,6 +59,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif
+        continue-on-error: true
 
       - name: Upload results artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

Backports the SARIF upload fix from `clouatre-labs/template-repo`: adds `continue-on-error: true` to every `github/codeql-action/upload-sarif` step across all workflows.

## Problem

`github/codeql-action/upload-sarif` fails on private repositories without GitHub Advanced Security (GHAS) with the error "Code Security must be enabled for this repository to use code scanning". GHAS is free for public repos but paid for private repos, so the SARIF upload step fails the job on private repos without a GHAS license.

## Fix

Add `continue-on-error: true` to each `upload-sarif` step. This lets the analysis tools (zizmor, poutine, Scorecard) run and report to job logs on all repos, while only the SARIF upload to the GitHub Security tab is non-fatal on private repos without GHAS.

`continue-on-error: true` is preferred over `if: github.repository_visibility == 'public'` (undocumented context property) or `if: github.event.repository.visibility == 'public'` (unreliable for `schedule` triggers) because it works for all trigger types with no property dependencies.

## Files changed

- `.github/workflows/ci.yml` - poutine job `upload-sarif` step
- `.github/workflows/scheduled-security-audit.yml` - poutine job `upload-sarif` step
- `.github/workflows/scorecard.yml` - Scorecard `upload-sarif` step

No other changes (zizmor, poutine, permissions) were touched.

## Sources

- [GitHub Docs - GHAS required](https://docs.github.com/en/enterprise-cloud@latest/code-security/reference/code-scanning/sarif-files/troubleshoot-sarif-uploads/ghas-required)
- [Community Discussion #169326](https://github.com/orgs/community/discussions/169326)
