### PR TITLE
fix(ci): gate scorecard to public repos only

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,9 @@ permissions: {}
 jobs:
   analyze:
     name: Scorecard analysis
+    # OpenSSF Scorecard only supports public repositories.
+    # Skip on private/internal repos to avoid GITHUB_TOKEN GraphQL access errors.
+    if: github.event.repository.visibility == 'public'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## Summary

Defensive gating for the OpenSSF Scorecard workflow. This repo is currently public, but adding the visibility gate ensures the job is skipped if the repo is ever made private, avoiding `Resource not accessible by integration` failures.

Backport of [template-repo PR #13](https://github.com/clouatre-labs/template-repo/pull/13).

## Changes

- **Gate job to public repos only**: `if: github.event.repository.visibility == 'public'` skips the job on private/internal repos.
- No hardcoded repo path to fix (uses `ossf/scorecard-action` which auto-detects).
